### PR TITLE
use sa for kubernetes driver

### DIFF
--- a/controllers/installation_controller.go
+++ b/controllers/installation_controller.go
@@ -234,6 +234,10 @@ func (r *InstallationReconciler) createJobForInstallation(ctx context.Context, j
 									Name:  "CLEANUP_JOBS",
 									Value: "false",
 								},
+								{
+									Name:  "SERVICE_ACCOUNT",
+									Value: agentCfg.ServiceAccount,
+								},
 							},
 							EnvFrom: []corev1.EnvFromSource{
 								// Environtment variables for the plugins


### PR DESCRIPTION
This change sets the service account for the Kubernetes Driver so that the installation image can connect to the Kubernetes cluster that it is running in