### PR TITLE
Fix testing with a local porter agent

### DIFF
--- a/config/rbac/agent_role.yaml
+++ b/config/rbac/agent_role.yaml
@@ -14,6 +14,13 @@ rules:
       - list
       - watch
   - apiGroups:
+    - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
+      - list
+  - apiGroups:
       - ""
     resources:
       - secrets

--- a/installer/helpers.sh
+++ b/installer/helpers.sh
@@ -44,9 +44,5 @@ remove-data() {
   kubectl delete pods -l porter=true --wait
 }
 
-uninstall() {
-  kubectl delete -f manifests/operator.yaml --ignore-not-found=true --wait
-}
-
 # Call the requested function and pass the arguments as-is
 "$@"

--- a/installer/porter.yaml
+++ b/installer/porter.yaml
@@ -123,11 +123,11 @@ remove-data:
 
 uninstall:
   # using exec instead of kubernetes because of https://github.com/getporter/kubernetes-mixin/issues/25
-  - exec:
+  - kubernetes:
       description: "Uninstall manifests"
-      command: ./helpers.sh
-      arguments:
-        - uninstall
+      manifests:
+        - manifests/operator.yaml
+      wait: true
 
 customActions:
   configure-namespace:


### PR DESCRIPTION
* add rbac for pod/logs so they are viewable from the porter agent job
* use v0.28.3 of k8s mixin to get fix for uninstall, so it can be repeated
* Fix using local images from the operator, and other magefile tweaks