### PR TITLE
Fix local config

### DIFF
--- a/config/rbac/agent_role.yaml
+++ b/config/rbac/agent_role.yaml
@@ -9,6 +9,7 @@ rules:
       - ""
     resources:
       - pods
+      - namespaces
     verbs:
       - get
       - list

--- a/magefile.go
+++ b/magefile.go
@@ -254,8 +254,8 @@ metadata:
   labels:
     porter: "true"
 spec:
-  porterRepository: localhost:5000/porter
-  porterVersion: canary
+  porterRepository: getporter/porter-agent
+  porterVersion: latest
   serviceAccount: porter-agent
 `
 	kubectl("apply", "--namespace", name, "-f", "-").


### PR DESCRIPTION
When running in a local dev env, e.g. running from source, the cluster role was missing access to namespaces which is now required by the k8s storage plugin.

Also we were still using the locally built porter image, instead of the agent image we are now publishing with new porter builds.
