### PR TITLE
Integrate the operator docs into website

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Porter
         uses: getporter/gh-action@v0.1.3
         with:
-          porter_version: v1.0.0-alpha.4
+          porter_version: v1.0.0-alpha.5
       - name: Set up Mage
         run: go run mage.go EnsureMage
       - name: Test

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,10 +1,12 @@
 ---
 title: Porter Operator
 description: Automate Porter on Kubernetes with the Porter Operator
+layout: single
 ---
 
 We are currently working on creating a Kubernetes operator for Porter.
 With Porter Operator, you define installations, credential sets and parameter sets in custom resources on a cluster, and the operator handles executing Porter when the desired state of an installation changes.
+Learn more about Porter manages desired state in the [Desired State QuickStart].
 
 ![architectural diagram showing that an installation resource triggers the operator to run a porter agent job, which then runs the bundle, saving state in mongodb](operator.png)
 
@@ -32,11 +34,16 @@ The image used for those jobs is called the **Porter Agent**.
 
 ### Agent Config
 
-How the Porter Agent is executed is configurable with the [**AgentConfig** CRD](resources.md#agent-config).
+How the Porter Agent is executed is configurable with the [**AgentConfig** CRD](/operator/file-formats/#agent-config).
 
 ### Porter Config
 
-The porter CLI has a [configuration file] when run normally on your local computer. When it's run inside the Porter Agent, you can populate the config file with a [PorterConfig CRD](resources.md#porter-config).
+The porter CLI has a [configuration file] when run normally on your local computer. When it's run inside the Porter Agent, you can populate the config file with a [PorterConfig CRD](/operator/file-formats/#porter-config).
 
 [porter installation apply]: /cli/porter_installations_apply/
-[configuration file]: https://release-v1.porter.sh/configuration/
+[configuration file]: /configuration/
+[Desired State QuickStart]: /quickstart/desired-state/
+
+## Next Steps
+
+* [QuickStart](/operator/quickstart/)

--- a/docs/content/file-formats.md
+++ b/docs/content/file-formats.md
@@ -19,7 +19,7 @@ The Installation CRD represents an installation of a bundle in Porter.
 The Installation CRD spec is a superset of the Installation resource in Porter, so it is safe to copy/paste the output of
 the `porter installation show NAME -o yaml` command into the spec field and have that be a valid installation.
 
-In addition to the normal fields available on a [Porter Installation document](https://release-v1--porter.netlify.app/reference/file-formats/)
+In addition to the normal fields available on a [Porter Installation document](/reference/file-formats/)
 the following fields are supported:
 
 | Field        | Required    | Default | Description |
@@ -126,5 +126,5 @@ Values are merged from all resolved PorterConfig resources, so that you can defi
 | storage | false | The mongodb server installed with the operator. | A list of named storage configurations. |
 | secrets | false | (empty) | A list of named secrets configurations. |
 
-[Porter Feature Flags]: https://release-v1.porter.sh/configuration/#experimental-feature-flags
-[configuration file](https://release-v1.porter.sh/configuration/)
+[Porter Feature Flags]: /configuration/#experimental-feature-flags
+[configuration file](/configuration/)

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -13,7 +13,7 @@ $ porter explain -r ghcr.io/getporter/porter-operator:canary
 Name: porter-operator
 Description: The Porter Operator for Kubernetes. Execute bundles on a Kubernetes cluster.
 Version: 1.0.0-alpha.1
-Porter Version: v1.0.0-alpha.4
+Porter Version: v1.0.0-alpha.5
 
 Credentials:
 Name         Description                                                          Required   Applies To
@@ -62,7 +62,7 @@ porter invoke porterops --action configureNamespace --param namespace=TODO -c po
 
 # Configuration
 
-The bundle accepts a parameter, porterConfig, that should be a YAML-formatted [Porter configuration file](https://release-v1.porter.sh/configuration).
+The bundle accepts a parameter, porterConfig, that should be a YAML-formatted [Porter configuration file](/configuration/).
 
 Here is an example of the default configuration used when none is specified:
 
@@ -103,5 +103,5 @@ The bundle also has parameters defined that control how the [Porter Agent] is co
 You can use the porter CLI to query and interact with installations created by the operator.
 Follow the instructions in [Connect to the in-cluster mongo database][connect] to point porter at the Mongodb server that was installed with the operator.
 
-[install Porter]: https://github.com/getporter/porter/releases/tag/v1.0.0-alpha.4
-[Porter Agent]: /docs/content/resources.md#agent-config
+[install the Porter v1 prerelease]: /install/#v1-prerelease
+[Porter Agent]: /operator/file-formats/#agent-config

--- a/docs/content/quickstart/_index.md
+++ b/docs/content/quickstart/_index.md
@@ -1,15 +1,18 @@
 ---
-title: QuickStart
+title: Porter Operator QuickStart
 description: Try out the Porter Operator!
+layout: single
 ---
 
-In this QuickStart you will learn how to install and use the Porter Operator on a non-production cluster.
+In this QuickStart you will learn how to install and use the [Porter Operator] on a non-production cluster.
+
+[Porter Operator]: /operator/
 
 # Prerequisites
 
 * [Install the latest Porter v1 prerelease][install-porter]
 * Docker, either a local installation or a remote Docker Host.
-* A Kubernetes cluster. [KinD] or Minikube works well.
+* A Kubernetes cluster. [KinD] or [Minikube] work well but follow the links for required configuration.
 * kubectl, with its kubeconfig configured to use the cluster.
 
 # Install the Operator
@@ -213,9 +216,9 @@ I chose retry, however you could use "favorite-color: blue", changing the value 
 
 You now know how to install and configure the Porter Operator. The project is still incomplete, so watch this repository for updates!
 
-* [Porter Operator Custom Resources](/docs/content/resources.md)
+* [Porter Operator Custom Resources](/operator/file-formats/)
 
-[install-porter]: https://github.com/getporter/porter/releases/tag/v1.0.0-alpha.4
-[KinD]: https://kind.sigs.k8s.io/docs/user/quick-start/#installation
-[Minikube]: https://minikube.sigs.k8s.io/docs/start/
+[install-porter]: /install/#v1-prerelease
+[KinD]: /best-practices/kind/
+[Minikube]: /best-practices/minikube/
 [getporter/hello-llama]: https://hub.docker.com/r/getporter/hello-llama


### PR DESCRIPTION
This tweaks the initial operator docs so that they display correctly on the porter website.
