### PR TITLE
Pin the default porter-agent to a specific version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Porter
         uses: getporter/gh-action@v0.1.3
         with:
-          porter_version: v1.0.0-alpha.7
+          porter_version: v1.0.0-alpha.8
       - name: Set up Mage
         run: go run mage.go EnsureMage
       - name: Test

--- a/api/v1/agentconfig_types.go
+++ b/api/v1/agentconfig_types.go
@@ -21,7 +21,8 @@ type AgentConfigSpec struct {
 	PorterRepository string `json:"porterRepository,omitempty" mapstructure:"porterRepository,omitempty"`
 
 	// PorterVersion is the tag for the Porter Agent image.
-	// Defaults to latest.
+	// Defaults to a well-known version of the agent that has been tested with the operator.
+	// Users SHOULD override this to use more recent versions.
 	PorterVersion string `json:"porterVersion,omitempty" mapstructure:"porterVersion,omitempty"`
 
 	// ServiceAccount is the service account to run the Porter Agent under.
@@ -50,7 +51,10 @@ type AgentConfigSpec struct {
 func (c AgentConfigSpec) GetPorterImage() string {
 	version := c.PorterVersion
 	if version == "" {
-		version = "latest"
+		// We don't use a mutable tag like latest, or canary because it's a bad practice that we don't want to encourage.
+		// As we test out the operator with new versions of Porter, keep this value up-to-date so that the default
+		// version is guaranteed to work.
+		version = "v1.0.0-alpha.8"
 	}
 	repo := c.PorterRepository
 	if repo == "" {

--- a/api/v1/agentconfig_types_test.go
+++ b/api/v1/agentconfig_types_test.go
@@ -12,7 +12,7 @@ import (
 func TestAgentConfigSpec_GetPorterImage(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
 		c := AgentConfigSpec{}
-		assert.Equal(t, "ghcr.io/getporter/porter-agent:latest", c.GetPorterImage())
+		assert.Equal(t, "ghcr.io/getporter/porter-agent:v1.0.0-alpha.8", c.GetPorterImage())
 	})
 
 	t.Run("porter version set", func(t *testing.T) {
@@ -21,8 +21,9 @@ func TestAgentConfigSpec_GetPorterImage(t *testing.T) {
 	})
 
 	t.Run("porter repository set", func(t *testing.T) {
+		// Test if someone has mirrored porter's agent to another registry
 		c := AgentConfigSpec{PorterRepository: "localhost:5000/myporter"}
-		assert.Equal(t, "localhost:5000/myporter:latest", c.GetPorterImage())
+		assert.Equal(t, "localhost:5000/myporter:v1.0.0-alpha.8", c.GetPorterImage())
 	})
 
 	t.Run("porter repository and version set", func(t *testing.T) {

--- a/config/crd/bases/porter.sh_agentconfigs.yaml
+++ b/config/crd/bases/porter.sh_agentconfigs.yaml
@@ -51,7 +51,9 @@ spec:
                 type: string
               porterVersion:
                 description: PorterVersion is the tag for the Porter Agent image.
-                  Defaults to latest.
+                  Defaults to a well-known version of the agent that has been tested
+                  with the operator. Users SHOULD override this to use more recent
+                  versions.
                 type: string
               pullPolicy:
                 description: PullPolicy specifies when to pull the Porter Agent image.

--- a/docs/content/file-formats.md
+++ b/docs/content/file-formats.md
@@ -31,7 +31,7 @@ the following fields are supported:
 
 The Porter Agent is a Kubernetes job that executes the porter CLI when an [installation resource](#installation) is modified.
 The agent is a Docker image with the porter CLI installed, and a custom entry point to assist with applying the Porter [configuration file].
-By default, the job uses the getporter/porter-agent:latest image.
+
 The AgentConfig CRD represents the configuration that the operator should use when executing Porter on Kubernetes, which is known as the Porter agent.
 
 A default AgentConfig is generated for you by the **configureNamespace** custom action of the porter-operator bundle.
@@ -45,7 +45,7 @@ metadata:
   name: customAgent
 spec:
   porterRepository: ghcr.io/getporter/porter-agent
-  porterVersion: canary
+  porterVersion: v1.0.0-alpha.8
   serviceAccount: porter-agent
   volumeSize: 64Mi
   pullPolicy: Always
@@ -63,7 +63,7 @@ Values are merged from all resolved AgentConfig resources, so that you can defin
 | Field        | Required    | Default | Description |
 | -----------  | ----------- | ------- | ----------- |
 | porterRepository  | false  | ghcr.io/getporter/porter-agent | The repository for the Porter Agent image. |
-| porterVersion | false      | latest  | The tag for the Porter Agent image. For example, vX.Y.Z, latest, or canary.  |
+| porterVersion | false      | varies  | The tag for the Porter Agent image. For example, vX.Y.Z, latest, or canary. Defaults to the most recent version of porter that has been tested with the operator.  |
 | serviceAccount | true | (none) | The service account to run the Porter Agent under. Must exist in the same namespace as the installation. |
 | installationServiceAccount | false | (none) | The service account to run the Kubernetes pod/job for the installation image. |
 | volumeSize | false | 64Mi | The size of the persistent volume that Porter will request when running the Porter Agent. It is used to share data between the Porter Agent and the bundle invocation image. It must be large enough to store any files used by the bundle including credentials, parameters and outputs. |

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ replace (
 )
 
 require (
-	get.porter.sh/porter v1.0.0-alpha.7.0.20220125144534-fb15bd907135
+	get.porter.sh/porter v1.0.0-alpha.8
 	github.com/carolynvs/magex v0.6.0
 	github.com/go-logr/logr v0.3.0
 	github.com/magefile/mage v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ contrib.go.opencensus.io/exporter/stackdriver v0.12.1/go.mod h1:iwB6wGarfphGGe/e
 contrib.go.opencensus.io/integrations/ocsql v0.1.4/go.mod h1:8DsSdjz3F+APR+0z0WkU1aRorQCFfRxvqjUUPMbF3fE=
 contrib.go.opencensus.io/resource v0.1.1/go.mod h1:F361eGI91LCmW1I/Saf+rX0+OFcigGlFvXwEGEnkRLA=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-get.porter.sh/porter v1.0.0-alpha.7.0.20220125144534-fb15bd907135 h1:SdKT7HaiqHNHh0V2EHj3sMScSJsSjEDYGnZgAlgNRUU=
-get.porter.sh/porter v1.0.0-alpha.7.0.20220125144534-fb15bd907135/go.mod h1:eG2RWoE+l/M3ooync0H/tT1dU5A5eHKppzo1IAOQGZY=
+get.porter.sh/porter v1.0.0-alpha.8 h1:P/+5U0r75+fn6ZUW6Lix4UgE1Pb9pLPc0XtraAgGeK0=
+get.porter.sh/porter v1.0.0-alpha.8/go.mod h1:eG2RWoE+l/M3ooync0H/tT1dU5A5eHKppzo1IAOQGZY=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 git.apache.org/thrift.git v0.12.0/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/AkihiroSuda/containerd-fuse-overlayfs v1.0.0/go.mod h1:0mMDvQFeLbbn1Wy8P2j3hwFhqBq+FKn8OZPno8WLmp8=


### PR DESCRIPTION
Do not use "latest" or "canary" when defaulting the porter-agent. We
don't want to encourage people to use mutable tags as it can easily
cause breakages when we release new versions.

We will bump this value each time we update the operator to work with a
new version of Porter instead. This is just for the default, so users
can always override it with an AgentConfig.

Fixes #51