### PR TITLE
Fixes for running operator on Azure (AKS)

### DIFF
--- a/controllers/installation_controller.go
+++ b/controllers/installation_controller.go
@@ -505,6 +505,12 @@ func (r *InstallationReconciler) createAgentJob(ctx context.Context, log logr.Lo
 					RestartPolicy:      "Never", // TODO: Make the retry policy configurable on the Installation
 					ServiceAccountName: agentCfg.ServiceAccount,
 					ImagePullSecrets:   nil, // TODO: Make pulling from a private registry possible
+					// Mount the volumes used by this pod as the nonroot user
+					// Porter's agent doesn't run as root and won't have access to files on the volume
+					// otherwise.
+					SecurityContext: &corev1.PodSecurityContext{
+						FSGroup: pointer.Int64Ptr(65532),
+					},
 				},
 			},
 		},

--- a/controllers/installation_controller_test.go
+++ b/controllers/installation_controller_test.go
@@ -591,6 +591,9 @@ func Test_createAgentJob(t *testing.T) {
 	assert.Equal(t, "porter-shared", podTemplate.Spec.Volumes[0].Name, "expected the porter-shared volume")
 	assert.Equal(t, "porter-config", podTemplate.Spec.Volumes[1].Name, "expected the porter-config volume")
 	assert.Equal(t, "porteraccount", podTemplate.Spec.ServiceAccountName, "incorrect service account for the pod")
+	assert.NotNil(t, podTemplate.Spec.SecurityContext, "incorrect pod security context")
+	nonroot := pointer.Int64Ptr(65532)
+	assert.Equal(t, nonroot, podTemplate.Spec.SecurityContext.FSGroup, "we should mount the pod volumes as the nonroot user")
 
 	// Verify the agent container
 	agentContainer := podTemplate.Spec.Containers[0]

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -3,7 +3,7 @@ title: Install the Porter Operator
 description: Get up and running with the Porter Operator
 ---
 
-If you aren't already familiar with Porter, we recommend that you [install the Porter v1 prerelease] first and then once you are comfortable, learn how to automate Porter with the operator.
+If you aren't already familiar with Porter, we recommend that you install and use [Porter v1.0.0-alpha.9][install-porter] first and then once you are comfortable, learn how to automate Porter with the operator.
 
 The commands below use the v0.3.0 release, but there may be a more recent release of the Operator.
 Check our [releases page](https://github.com/getporter/operator/releases) and use the most recent version number.
@@ -15,8 +15,8 @@ First, use explain to see what credentials and parameters you can use when insta
 $ porter explain -r ghcr.io/getporter/porter-operator:v0.3.0
 Name: porter-operator
 Description: The Porter Operator for Kubernetes. Execute bundles on a Kubernetes cluster.
-Version: 1.0.0-alpha.1
-Porter Version: v1.0.0-alpha.5
+Version: v0.3.0
+Porter Version: v1.0.0-alpha.9
 
 Credentials:
 Name         Description                                                          Required   Applies To
@@ -106,5 +106,5 @@ The bundle also has parameters defined that control how the [Porter Agent] is co
 You can use the porter CLI to query and interact with installations created by the operator.
 Follow the instructions in [Connect to the in-cluster mongo database][connect] to point porter at the Mongodb server that was installed with the operator.
 
-[install the Porter v1 prerelease]: /install/#v1-prerelease
+[install-porter]: https://github.com/getporter/porter/releases?q=v1.0.0&expanded=true
 [Porter Agent]: /operator/file-formats/#agent-config

--- a/docs/content/quickstart/_index.md
+++ b/docs/content/quickstart/_index.md
@@ -10,7 +10,7 @@ In this QuickStart you will learn how to install and use the [Porter Operator] o
 
 ## Prerequisites
 
-* [Install the latest Porter v1 prerelease][install-porter]
+* [Install the most recent Porter v1 prerelease][install-porter]
 * Docker, either a local installation or a remote Docker Host.
 * A Kubernetes cluster. [KinD] or [Minikube] work well but follow the links for required configuration.
 * kubectl, with its kubeconfig configured to use the cluster.
@@ -284,7 +284,7 @@ You now know how to install and configure the Porter Operator. The project is st
 
 * [Porter Operator Custom Resources](/operator/file-formats/)
 
-[install-porter]: /install/#v1-prerelease
+[install-porter]: https://github.com/getporter/porter/releases?q=v1.0.0&expanded=true
 [KinD]: /best-practices/kind/
 [Minikube]: /best-practices/minikube/
 [getporter/hello-llama]: https://hub.docker.com/r/getporter/hello-llama


### PR DESCRIPTION
* Set fsGroup on porter agent pod

    We had only tested our installation on KinD, which doesn't seem to have
the same file permissions on its default storage class. When we tried to
run the operator on Azure (AKS), we found that the agent couldn't write
to the mounted volume (/porter-shared).

    The porter agent runs as nonroot, not root, as part of our hardening
process for IronBank. So when the volume is mounted, it needs to be
marked with the same user id for nonroot so that the container has
permission to write to the volume.

* Clarify which version of porter is required for operator

    The operator (v0.3.0) requires porter v1.0.0-alpha.8+. Our docs had hard
coded a previous version in our installation commands which confused
users. I've added text that explains which version to use, and prompt
them to check for more recent versions of porter.