### PR TITLE
Recommend installing v0.4.0

### DIFF
--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -5,17 +5,17 @@ description: Get up and running with the Porter Operator
 
 If you aren't already familiar with Porter, we recommend that you install and use [Porter v1.0.0-alpha.9][install-porter] first and then once you are comfortable, learn how to automate Porter with the operator.
 
-The commands below use the v0.3.0 release, but there may be a more recent release of the Operator.
+The commands below use the v0.4.0 release, but there may be a more recent release of the Operator.
 Check our [releases page](https://github.com/getporter/operator/releases) and use the most recent version number.
 
 The Porter Operator is installed with ... Porter!
 First, use explain to see what credentials and parameters you can use when installing and configuring the operator.
 
 ```
-$ porter explain -r ghcr.io/getporter/porter-operator:v0.3.0
+$ porter explain -r ghcr.io/getporter/porter-operator:v0.4.0
 Name: porter-operator
 Description: The Porter Operator for Kubernetes. Execute bundles on a Kubernetes cluster.
-Version: v0.3.0
+Version: v0.4.0
 Porter Version: v1.0.0-alpha.9
 
 Credentials:
@@ -43,12 +43,12 @@ This bundle uses the following tools: exec, helm3, kubernetes.
 
 Generate a credential set for the bundle, the only required credential for the operator is a kubeconfig for the cluster that the operator is to be installed in.
 ```
-porter credentials generate porterops -r ghcr.io/getporter/porter-operator:v0.3.0
+porter credentials generate porterops -r ghcr.io/getporter/porter-operator:v0.4.0
 ```
 
 Install the operator into the porter-operator-system namespace:
 ```
-porter install porterops -c porterops -r ghcr.io/getporter/porter-operator:v0.3.0
+porter install porterops -c porterops -r ghcr.io/getporter/porter-operator:v0.4.0
 ```
 
 Create a namespace with the appropriate RBAC and configuration. This namespace is where you will create installation CRDs and the operator will create corresponding Jobs to execute the porter CLI.

--- a/docs/content/quickstart/_index.md
+++ b/docs/content/quickstart/_index.md
@@ -20,17 +20,17 @@ In this QuickStart you will learn how to install and use the [Porter Operator] o
 The Porter Operator is installed using Porter, and requires an existing Kubernetes cluster.
 First, generate a credential set that points to the location of your kubeconfig file, for example using the path $HOME/.kube/config.
 
-The commands below use the v0.3.0 release, but there may be a more recent release of the Operator.
+The commands below use the v0.4.0 release, but there may be a more recent release of the Operator.
 Check our [releases page](https://github.com/getporter/operator/releases) and use the most recent version number.
 
 ```
-porter credentials generate porterops -r ghcr.io/getporter/porter-operator:v0.3.0
+porter credentials generate porterops -r ghcr.io/getporter/porter-operator:v0.4.0
 ```
 
 Now that Porter knows which cluster to target, install the Operator with the following command:
 
 ```
-porter install porterops -c porterops -r ghcr.io/getporter/porter-operator:v0.3.0
+porter install porterops -c porterops -r ghcr.io/getporter/porter-operator:v0.4.0
 ```
 
 Before you use the operator, you need to configure a Kubernetes namespace with the necessary configuration.


### PR DESCRIPTION
v0.3.0 has a bug and can't run invocation images. Update all docs to use v0.4.0 in the examples so that people are less likely to use the buggy version.
