### PR TITLE
Reconcile when owned jobs change

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -17,6 +17,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -59,8 +60,8 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	err = porterv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(clientgoscheme.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(porterv1.AddToScheme(scheme.Scheme)).To(Succeed())
 
 	// +kubebuilder:scaffold:scheme
 

--- a/main.go
+++ b/main.go
@@ -27,7 +27,6 @@ var (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-
 	utilruntime.Must(portershv1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }


### PR DESCRIPTION
I had put in code to trigger reconcile when a job that we created changes, but it actually wasn't working.

* Only filter events for installations, so that jobs aren't filtered out
* Set the owner reference using the k8s library because I was doing it wrong. The controller flag wasn't also set.
