### PR TITLE
Make test wait time configurable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,8 @@ jobs:
         run: go run mage.go EnsureMage
       - name: Test
         run: mage -v Test
+        env:
+          PORTER_TEST_WAIT_TIMEOUT: 2m
       - name: Report Unit Test Coverage
         uses: codecov/codecov-action@v1
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@
   * [Run a test installation](#run-a-test-installation)  
   * [Modify the porter agent](#modify-the-porter-agent)
   * [Publish to another registry](#publish-to-another-registry)
+  * [Increase Test Timeout](#increase-test-timeout)
 ---
 
 # New Contributor Guide
@@ -158,4 +159,20 @@ For example, when you are testing the operator on a real cluster instead of KinD
 export PORTER_ENV=custom # this can be anything but production or test
 export PORTER_OPERATOR_REGISTRY=ghcr.io/getporter/test # Set this to a registry for which you have push access
 mage publish
+```
+
+## Increase Test Timeout
+
+The ginkgo integration tests interact with a real cluster, and sometimes that means that things take longer depending on the machine you are running on.
+If you are seeing timeouts while running the tests like the example error below, you can increase the time that the tests wait for an action to finish by setting the `PORTER_TEST_WAIT_TIMEOUT` environment variable to a Go time.Duration string value such as "30s" or "2m".
+
+```plain
+Installation Lifecycle
+/home/runner/work/operator/operator/tests/integration/installation_test.go:27
+  When an installation is changed
+  /home/runner/work/operator/operator/tests/integration/installation_test.go:28
+    Should run porter [It]
+    /home/runner/work/operator/operator/tests/integration/installation_test.go:29
+    timeout waiting for installation to delete: context deadline exceeded
+    /home/runner/work/operator/operator/tests/integration/installation_test.go:150
 ```

--- a/tests/integration/installation_test.go
+++ b/tests/integration/installation_test.go
@@ -147,9 +147,12 @@ func debugFailedInstallation(ctx context.Context, inst *porterv1.Installation) {
 func getWaitTimeout() time.Duration {
 	if value := os.Getenv("PORTER_TEST_WAIT_TIMEOUT"); value != "" {
 		timeout, err := time.ParseDuration(value)
-		if err == nil {
-			return timeout
+		if err != nil {
+			fmt.Printf("WARNING: An invalid value, %q, was set for PORTER_TEST_WAIT_TIMEOUT environment variable. The format should be a Go time duration such as 30s or 1m. Ignoring and using the default instead", value)
+			return defaultWaitTimeout
 		}
+
+		return timeout
 	}
 	return defaultWaitTimeout
 }

--- a/tests/integration/installation_test.go
+++ b/tests/integration/installation_test.go
@@ -6,6 +6,7 @@ package integration_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	porterv1 "get.porter.sh/operator/api/v1"
@@ -23,6 +24,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// The default amount of time to wait while a test action is processed.
+const defaultWaitTimeout = 120 * time.Second
 
 var _ = Describe("Installation Lifecycle", func() {
 	Context("When an installation is changed", func() {
@@ -82,7 +86,7 @@ var _ = Describe("Installation Lifecycle", func() {
 func waitForPorter(ctx context.Context, inst *porterv1.Installation, msg string) error {
 	Log("%s: %s/%s", msg, inst.Namespace, inst.Name)
 	key := client.ObjectKey{Namespace: inst.Namespace, Name: inst.Name}
-	ctx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, getWaitTimeout())
 	defer cancel()
 	for {
 		select {
@@ -139,10 +143,21 @@ func debugFailedInstallation(ctx context.Context, inst *porterv1.Installation) {
 	Log("DEBUG: ----------------------------------------------------")
 }
 
+// Get the amount of time that we should wait for a test action to be processed.
+func getWaitTimeout() time.Duration {
+	if value := os.Getenv("PORTER_TEST_WAIT_TIMEOUT"); value != "" {
+		timeout, err := time.ParseDuration(value)
+		if err == nil {
+			return timeout
+		}
+	}
+	return defaultWaitTimeout
+}
+
 func waitForInstallationDeleted(ctx context.Context, inst *porterv1.Installation) error {
 	Log("Waiting for installation to finish deleting: %s/%s", inst.Namespace, inst.Name)
 	key := client.ObjectKey{Namespace: inst.Namespace, Name: inst.Name}
-	waitCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	waitCtx, cancel := context.WithTimeout(ctx, getWaitTimeout())
 	defer cancel()
 	for {
 		select {


### PR DESCRIPTION
The ginkgo tests often have to trigger the controller with a change, like editing an installation resource, and then wait for the controller to react and the resulting porter action jobs to finish.

Depending on if you already have the images pulled, and how fast your machine is, this can take a pretty variable amount of time. I've made the wait time configurable so that we can increase it on our CI build.