### PR TITLE
force publish to latest release tag 

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -237,7 +237,7 @@ func PublishBundle() {
 	meta := releases.LoadMetadata()
 	buildPorterCmd("publish", "--registry", Env.Registry, "-f=porter.yaml", "--tag", meta.Version).In("installer").Must().RunV()
 
-	buildPorterCmd("publish", "--registry", Env.Registry, "-f=porter.yaml", "--tag", meta.Permalink).In("installer").Must().RunV()
+	buildPorterCmd("publish", "--registry", Env.Registry, "-f=porter.yaml", "--tag", meta.Permalink, "--force").In("installer").Must().RunV()
 }
 
 // Generate k8s manifests for the operator.


### PR DESCRIPTION
Since porter now has the capability to detect bundle overwrite, we need to add the `--force` flag to push to the `latest` tag