### PR TITLE
update doc to v0.7.1

### DIFF
--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -1,0 +1,49 @@
+# Cut a Release
+
+🧀💨
+
+Our CI system watches for tags, and when a tag is pushed, cuts a release
+of Porter. When you are asked to cut a new release, here is the process:
+
+1. Figure out the correct version number using our [version strategy].
+    * Bump the major segment if there are any breaking changes, and the 
+      version is greater than v1.0.0
+    * Bump the minor segment if there are new features only.
+    * Bump the patch segment if there are bug fixes only.
+    * Bump the pre-release number (version-prerelease.NUMBER) if this is
+      a pre-release, e.g. alpha/beta/rc.
+1. First, ensure that the main CI build has already passed for 
+    the [commit that you want to tag][commits], and has published the canary binaries. 
+    
+    Then create the tag and push it:
+
+    ```
+    git checkout main
+    git pull
+    git tag VERSION -a -m ""
+    git push --tags
+    ```
+    If the CI build failed to build for the release, fix the problem first. 
+    Then increment the PATCH version, e.g. v0.7.0->v0.7.1, and go through the above steps again to publish the binaries. 
+    It's often a good pratice to finish the release first before updating any of our docs that references the latest release.
+
+1. Generate some release notes and put them into the release on GitHub.
+   - Go to Operator Github repository and find the newly created release tag. You should see a
+   "auto generate release notes" button to create release notes for the release.
+   - Modify the generated release note to call out any breaking or notable changes in the release.
+   - Include instructions for installing or upgrading to the new release:
+    ```
+      # Install or Upgrade
+      Run (or re-run) the installation from https://getporter.org/operator/install/ to get the
+    latest version of operator.
+    ```
+1. Announce the new release in the community.
+   - Email the [mailing list](https://getporter.org/mailing-list) to announce the release. In your email, call out any breaking or notable changes.
+   - Post a message in [Porter's slack channel](https://getporter.org/community/#slack).
+1. If there are any issues fixed in the release and someone is waiting for the fix, comment on the issue to let them know and link to the release.
+1. If the release contains new features, it should be announced through a [blog](https://getporter.org/blog/) post and on Porter's twitter account.
+
+[maintainers]: https://github.com/orgs/getporter/teams/maintainers
+[admins]: https://github.com/orgs/getporter/teams/admins
+[commits]: https://github.com/getporter/porter/commits/main
+[version strategy]: https://getporter.org/project/version-strategy/

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -5,17 +5,17 @@ description: Get up and running with the Porter Operator
 
 If you aren't already familiar with Porter, we recommend that you install and use [Porter v1.0.0-rc.1][install-porter] first and then once you are comfortable, learn how to automate Porter with the operator.
 
-The commands below use the v0.7.0 release, but there may be a more recent release of the Operator.
+The commands below use the v0.7.1 release, but there may be a more recent release of the Operator.
 Check our [releases page](https://github.com/getporter/operator/releases) and use the most recent version number.
 
 The Porter Operator is installed with ... Porter!
 First, use explain to see what credentials and parameters you can use when installing and configuring the operator.
 
 ```
-$ porter explain -r ghcr.io/getporter/porter-operator:v0.7.0
+$ porter explain -r ghcr.io/getporter/porter-operator:v0.7.1
 Name: porter-operator
 Description: The Porter Operator for Kubernetes. Execute bundles on a Kubernetes cluster.
-Version: 0.7.0
+Version: v0.7.1
 Porter Version: v1.0.0-rc.1
 
 Credentials:
@@ -86,17 +86,17 @@ This bundle uses the following tools: exec, helm3, kubernetes.
 
 To install this bundle run the following command, passing --param KEY=VALUE for any parameters you want to customize:
 porter credentials generate mycreds --reference ghcr.io/getporter/porter-operator:v0.5.0
-porter install --reference ghcr.io/getporter/porter-operator:v0.7.0 -c mycreds
+porter install --reference ghcr.io/getporter/porter-operator:v0.7.1 -c mycreds
 ```
 
 Generate a credential set for the bundle, the only required credential for the operator is a kubeconfig for the cluster that the operator is to be installed in.
 ```
-porter credentials generate porterops -r ghcr.io/getporter/porter-operator:v0.7.0
+porter credentials generate porterops -r ghcr.io/getporter/porter-operator:v0.7.1
 ```
 
 Install the operator into the porter-operator-system namespace:
 ```
-porter install porterops -c porterops -r ghcr.io/getporter/porter-operator:v0.7.0
+porter install porterops -c porterops -r ghcr.io/getporter/porter-operator:v0.7.1
 ```
 
 Create a namespace with the appropriate RBAC and configuration. This namespace is where you will create installation CRDs and the operator will create corresponding Jobs to execute the porter CLI.

--- a/docs/content/quickstart/_index.md
+++ b/docs/content/quickstart/_index.md
@@ -20,17 +20,17 @@ In this QuickStart you will learn how to install and use the [Porter Operator] o
 The Porter Operator is installed using Porter, and requires an existing Kubernetes cluster.
 First, generate a credential set that points to the location of your kubeconfig file, for example using the path $HOME/.kube/config.
 
-The commands below use the v0.7.0 release, but there may be a more recent release of the Operator.
+The commands below use the v0.7.1 release, but there may be a more recent release of the Operator.
 Check our [releases page](https://github.com/getporter/operator/releases) and use the most recent version number.
 
 ```
-porter credentials generate porterops -r ghcr.io/getporter/porter-operator:v0.7.0
+porter credentials generate porterops -r ghcr.io/getporter/porter-operator:v0.7.1
 ```
 
 Now that Porter knows which cluster to target, install the Operator with the following command:
 
 ```
-porter install porterops -c porterops -r ghcr.io/getporter/porter-operator:v0.7.0
+porter install porterops -c porterops -r ghcr.io/getporter/porter-operator:v0.7.1
 ```
 
 Before you use the operator, you need to configure a Kubernetes namespace with the necessary configuration.


### PR DESCRIPTION
now that the `v0.7.1` is published, we can update the doc to reflect that.
This PR also adds a REVIEWING.md to document our release process for the operator