### PR TITLE
Update to go 1.19.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4
 
 # Build the manager binary
-FROM golang:1.19 as builder
+FROM golang:1.19.4 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@
   command = "go run mage.go -v DocsDeploy"
 
   [build.environment]
-    GO_VERSION = "1.19.3"
+    GO_VERSION = "1.19.4"
 
 [context.branch-deploy]
   command = "go run mage.go -v DocsDeployPreview"


### PR DESCRIPTION
Updating to Go 1.19.4 because it contains security patches for two CVEs

https://go.dev/doc/devel/release#go1.19.4

1. CVE-2022-41720 and Go issue https://go.dev/issue/56694.
2. CVE-2022-41717 and Go issue https://go.dev/issue/56350.
