### PR TITLE
update mongodb helm chart default version to v12.1.16

### DIFF
--- a/installer/vanilla.porter.yaml
+++ b/installer/vanilla.porter.yaml
@@ -65,7 +65,7 @@ parameters:
   - name: mongodbChartVersion
     description: Version of the mongodb helm chart to install
     type: string
-    default: "12.1.15"
+    default: "12.1.16"
     applyTo:
       - install
 


### PR DESCRIPTION
mongodb helm chart no longer has 12.1.15 available. This PR updates it to 12.1.16