### PR TITLE
change porter config crd to use the same naming conventions as Porter

### DIFF
--- a/api/v1/porterconfig_types.go
+++ b/api/v1/porterconfig_types.go
@@ -30,19 +30,19 @@ type PorterConfigSpec struct {
 
 	// BuildDriver specifies the name of the current build driver.
 	// Requires that the build-drivers experimental feature is enabled.
-	BuildDriver *string `json:"buildDriver,omitempty" yaml:"build-driver,omitempty" mapstructure:"build-driver,omitempty"`
+	BuildDriver *string `json:"build-driver,omitempty" yaml:"build-driver,omitempty" mapstructure:"build-driver,omitempty"`
 
 	// DefaultStorage is the name of the storage configuration to use.
-	DefaultStorage *string `json:"defaultStorage,omitempty" yaml:"default-storage,omitempty" mapstructure:"default-storage,omitempty"`
+	DefaultStorage *string `json:"default-storage,omitempty" yaml:"default-storage,omitempty" mapstructure:"default-storage,omitempty"`
 
 	// DefaultSecrets is the name of the secrets configuration to use.
-	DefaultSecrets *string `json:"defaultSecrets,omitempty" yaml:"default-secrets,omitempty" mapstructure:"default-secrets,omitempty"`
+	DefaultSecrets *string `json:"default-secrets,omitempty" yaml:"default-secrets,omitempty" mapstructure:"default-secrets,omitempty"`
 
 	// DefaultStoragePlugin is the name of the storage plugin to use when DefaultStorage is unspecified.
-	DefaultStoragePlugin *string `json:"defaultStoragePlugin,omitempty" yaml:"default-storage-plugin,omitempty" mapstructure:"default-storage-plugin,omitempty"`
+	DefaultStoragePlugin *string `json:"default-storage-plugin,omitempty" yaml:"default-storage-plugin,omitempty" mapstructure:"default-storage-plugin,omitempty"`
 
 	// DefaultSecretsPlugin is the name of the storage plugin to use when DefaultSecrets is unspecified.
-	DefaultSecretsPlugin *string `json:"defaultSecretsPlugin,omitempty" yaml:"default-secrets-plugin,omitempty" mapstructure:"default-secrets-plugin,omitempty"`
+	DefaultSecretsPlugin *string `json:"default-secrets-plugin,omitempty" yaml:"default-secrets-plugin,omitempty" mapstructure:"default-secrets-plugin,omitempty"`
 
 	// Storage is a list of named storage configurations.
 	Storage []StorageConfig `json:"storage,omitempty" yaml:"storage,omitempty" mapstructure:"storage,omitempty"`

--- a/config/crd/bases/getporter.org_porterconfigs.yaml
+++ b/config/crd/bases/getporter.org_porterconfigs.yaml
@@ -38,23 +38,23 @@ spec:
               Use yaml to convert to Porter's representation of the resource. The
               mapstructure tags are used internally for PorterConfigSpec.MergeConfig."
             properties:
-              buildDriver:
+              build-driver:
                 description: BuildDriver specifies the name of the current build driver.
                   Requires that the build-drivers experimental feature is enabled.
                 type: string
-              defaultSecrets:
+              default-secrets:
                 description: DefaultSecrets is the name of the secrets configuration
                   to use.
                 type: string
-              defaultSecretsPlugin:
+              default-secrets-plugin:
                 description: DefaultSecretsPlugin is the name of the storage plugin
                   to use when DefaultSecrets is unspecified.
                 type: string
-              defaultStorage:
+              default-storage:
                 description: DefaultStorage is the name of the storage configuration
                   to use.
                 type: string
-              defaultStoragePlugin:
+              default-storage-plugin:
                 description: DefaultStoragePlugin is the name of the storage plugin
                   to use when DefaultStorage is unspecified.
                 type: string

--- a/config/samples/_v1_porterconfig.yaml
+++ b/config/samples/_v1_porterconfig.yaml
@@ -6,8 +6,8 @@ metadata:
     getporter.org/testdata: "true"
 spec:
   verbosity: debug
-  defaultSecretsPlugin: kubernetes.secrets
-  defaultStorage: in-cluster-mongodb
+  default-secretsPlugin: kubernetes.secrets
+  default-storage: in-cluster-mongodb
   storage:
     - name: in-cluster-mongodb
       plugin: mongodb

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -119,10 +119,10 @@ Here is an example of the default configuration used when none is specified:
 
 ```yaml
 # Resolve secrets using secrets on the cluster in the current namespace.
-defaultSecretsPlugin: "kubernetes.secrets"
+default-secrets-plugin: "kubernetes.secrets"
 
 # Use the mongodb server that was deployed with the operator
-defaultStorage: "in-cluster-mongodb"
+default-storage: "in-cluster-mongodb"
 storage:
   - name: "in-cluster-mongodb"
     plugin: "mongodb"

--- a/installer/helpers.sh
+++ b/installer/helpers.sh
@@ -19,10 +19,6 @@ configureNamespace() {
     echo "Using the default porter configuration"
     cp defaults/porter-config-spec.yaml $spec
   fi
-  sed -i 's/default-storage-plugin/defaultStoragePlugin/g' $spec
-  sed -i 's/default-storage/defaultStorage/g' $spec
-  sed -i 's/default-secrets-plugin/defaultSecretsPlugin/g' $spec
-  sed -i 's/default-secrets/defaultSecrets/g' $spec
   yq eval-all 'select(fileIndex==0).spec = select(fileIndex==1) | select(fileIndex==0)' -i porter-config.yaml $spec
 
   # If settings were specified for the porter operator, create a AgentConfig with them included


### PR DESCRIPTION
In order for a user to be able to just copy/paste a Porter resource into the spec of the CRD and it just works, the naming for PorterConfig CRD needs to be updated from camel case to seperated by hyphen.
relates to: #124 