### PR TITLE
155 support multiple architecture image publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: build
-on: 
+on:
   workflow_dispatch: {}
   push: {}
   pull_request: {}
@@ -54,6 +54,14 @@ jobs:
           password: ${{ secrets.GHCR_TOKEN }}
       - name: Publish
         if: ${{ github.event_name != 'pull_request' }}
-        run: mage -v Publish
+        run: |
+          if [[ "${GITHUB_REPOSITORY}" != "getporter/operator" ]]; then
+          # If publishing from fork PORTER_OPERATOR_REGISTRY
+          # must be set as a CI env variable and GHCR_USER and GHCR_TOKEN set
+          # as secrets with permissions to publish images
+          export PORTER_ENV=fork
+          export PORTER_OPERATOR_REGISTRY=${{ vars.PORTER_OPERATOR_REGISTRY }}
+          fi
+          mage -v Publish
         env:
           PORTER_ENV: production

--- a/docker-bake.json
+++ b/docker-bake.json
@@ -1,0 +1,15 @@
+
+{
+  "group": {
+    "default": {
+      "targets": ["porter"]
+    }
+  },
+  "target": {
+    "porter": {
+      "platforms": ["linux/amd64", "linux/arm64"],
+      "dockerfile": "Dockerfile",
+      "context": "./"
+    }
+  }
+}

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -198,7 +198,7 @@ func getMixins() error {
 
 // Publish the operator and its bundle.
 func Publish() {
-	mg.Deps(PublishImages, PublishBundle)
+	mg.Deps(PublishMultiArchImages, PublishBundle)
 }
 
 // Push the porter-operator bundle to a registry. Defaults to the local test registry.
@@ -367,6 +367,16 @@ func PublishImages() {
 
 	log.Println("Pushing", imgPermalink)
 	must.RunV("docker", "push", imgPermalink)
+}
+
+func PublishMultiArchImages() {
+	meta := releases.LoadMetadata()
+	img := Env.ManagerImagePrefix + meta.Version
+	imgPermalink := Env.ManagerImagePrefix + meta.Permalink
+
+	log.Printf("Multi-arch build and push of %s and %s\n", img, imgPermalink)
+	must.RunV("docker", "buildx", "create", "--use")
+	must.RunV("docker", "buildx", "bake", "-f", "docker-bake.json", "--push", "--set", "porter.tags="+img, "--set", "porter.tags="+imgPermalink, "porter")
 }
 
 func PublishLocalPorterAgent() {


### PR DESCRIPTION
# What does this change
* Adding a final multi arch image build for arm and x86
* Added logic to final CI step supporting publish from a fork

CI changes only

# What issue does it fix
Closes #155

[1]: https://getporter.org/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
My goal was not to change any existing test logic.  Some refactoring to the kind test env would
allow a `docker buildx bake` pattern to be used in more places.

# Checklist
- [ ] Did you write tests?
- [x] Did you write documentation?  (added note in gitlab actions with instructions to publish from fork)
- [ ] Did you make any API changes? Update the corresponding API documentation.

[contributors]: https://getporter.org/src/CONTRIBUTORS.md