### PR TITLE
Do not mount plugins pvc when none specified

### DIFF
--- a/api/v1/agentconfig_types.go
+++ b/api/v1/agentconfig_types.go
@@ -247,6 +247,7 @@ func NewAgentConfigSpecAdapter(spec AgentConfigSpec) AgentConfigSpecAdapter {
 }
 
 // GetPluginsPVCName returns a name used for this agent config plugin persistent volume claim.
+// Returns an empty string when no plugins are specified, in which case the PVC should not be mounted
 func (c AgentConfigSpecAdapter) GetPluginsPVCName(namespace string) string {
 	return c.Plugins.GetPVCName(namespace)
 }

--- a/api/v1/const.go
+++ b/api/v1/const.go
@@ -96,14 +96,15 @@ const (
 	// .docker/config.json file.
 	VolumeImgPullSecretName = "img-pull-secret"
 
-	// VolumeImagePullSecretPath is the mount path of the volume containing for docker
+	// VolumeImgPullSecretPath is the mount path of the volume containing for docker
 	// auth for image pull secrets.
 	VolumeImgPullSecretPath = "/home/nonroot"
-	// VolumePorterSharedName is the name of the volume shared between the porter
+
+	// VolumePorterPluginsName is the name of the volume shared between the porter
 	// agent and the invocation image.
 	VolumePorterPluginsName = "porter-plugins"
 
-	// VolumePorterConfigPath is the mount path of the volume containing Porter's
+	// VolumePorterPluginsPath is the mount path of the volume containing Porter's
 	// config file.
 	VolumePorterPluginsPath = "/app/.porter/plugins"
 )


### PR DESCRIPTION
# What does this change
When no plugins are specified by the AgentConfig, the plugins PVC will be an empty string and the PVC should not be mounted. I have updated the job creation logic to check if the PVC name is empty and skip mounting when no plugins are specified.

I have also updated the logging so that when we fail to create a job from an AgentAction, we log the job yaml (base64 encoded) so that we can troubleshoot better.

For context, this came up when I updated the k8s plugin to use the latest version of the operator. Since it wasn't specifying any plugins, the tests were all failing because none of the action action jobs could be created, due to the empty pvc name on the job.

# What issue does it fix
Closes #165 

# Notes for the reviewer
Depending on what @VinozzZ thinks about if we should default to the k8s plugin when nothing is specified, there may be a follow-up to tweak this code. But for now this fixes the v0.8.0 release.

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you make any API changes? Update the corresponding API documentation.

[contributors]: https://getporter.org/src/CONTRIBUTORS.md