### PR TITLE
167 plugin volume not about to be mounted into agent action job on aks

### DIFF
--- a/api/v1/agentconfig_types.go
+++ b/api/v1/agentconfig_types.go
@@ -52,6 +52,11 @@ type AgentConfigSpec struct {
 	// +optional
 	ServiceAccount string `json:"serviceAccount,omitempty" mapstructure:"serviceAccount,omitempty"`
 
+	// StorageClassName is the name of the storage class that Porter will request
+	// when running the Porter Agent. It is used to determine what the storage class
+	// will be for the volume requested
+	StorageClassName string `json:"storageClassName,omitempty" mapstructure:"storageClassName,omitempty"`
+
 	// VolumeSize is the size of the persistent volume that Porter will
 	// request when running the Porter Agent. It is used to share data
 	// between the Porter Agent and the bundle invocation image. It must
@@ -284,6 +289,12 @@ func (c AgentConfigSpecAdapter) GetPullPolicy() v1.PullPolicy {
 		return v1.PullAlways
 	}
 	return v1.PullIfNotPresent
+}
+
+// GetStorageClassName returns the name of the storage class to request for the
+// volume.
+func (c AgentConfigSpecAdapter) GetStorageClassName() string {
+	return c.original.StorageClassName
 }
 
 // GetVolumeSize returns the size of the shared volume to mount between the

--- a/api/v1/agentconfig_types_test.go
+++ b/api/v1/agentconfig_types_test.go
@@ -65,6 +65,19 @@ func TestAgentConfigSpecAdapter_GetPullPolicy(t *testing.T) {
 	}
 }
 
+func TestAgentConfigSpecAdapter_GetStorageClassName(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		c := AgentConfigSpec{}
+		cl := NewAgentConfigSpecAdapter(c)
+		assert.Equal(t, "", cl.GetStorageClassName())
+	})
+	t.Run("azureblob-nfs-premium", func(t *testing.T) {
+		c := AgentConfigSpec{StorageClassName: "azureblob-nfs-premium"}
+		cl := NewAgentConfigSpecAdapter(c)
+		assert.Equal(t, "azureblob-nfs-premium", cl.GetStorageClassName())
+	})
+}
+
 func TestAgentConfigSpecAdapter_GetVolumeSize(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
 		c := AgentConfigSpec{}

--- a/config/crd/bases/getporter.org_agentconfigs.yaml
+++ b/config/crd/bases/getporter.org_agentconfigs.yaml
@@ -98,6 +98,13 @@ spec:
                 description: ServiceAccount is the service account to run the Porter
                   Agent under.
                 type: string
+              storageClassName:
+                description: StorageClassName is the name of the storage class that
+                  Porter will request when running the Porter Agent. It is used to
+                  determine what the storage class will be for the volume requested.
+                  The storage class must support ReadWriteOnce and ReadOnlyMany access modes
+                  as well as allow for 'chmod' to be executed.
+                type: string
               volumeSize:
                 description: VolumeSize is the size of the persistent volume that
                   Porter will request when running the Porter Agent. It is used to

--- a/controllers/agentaction_controller.go
+++ b/controllers/agentaction_controller.go
@@ -247,7 +247,7 @@ func (r *AgentActionReconciler) createAgentVolume(ctx context.Context, log logr.
 	if len(results.Items) > 0 {
 		return &results.Items[0], nil
 	}
-
+	storageClassName := agentCfg.GetStorageClassName()
 	// Create a volume to share data between porter and the invocation image
 	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
@@ -263,6 +263,9 @@ func (r *AgentActionReconciler) createAgentVolume(ctx context.Context, log logr.
 				},
 			},
 		},
+	}
+	if storageClassName != "" {
+		pvc.Spec.StorageClassName = &storageClassName
 	}
 
 	if err := r.Create(ctx, pvc); err != nil {

--- a/docs/content/administrators/configure-porter-agent.md
+++ b/docs/content/administrators/configure-porter-agent.md
@@ -8,6 +8,7 @@ The Porter Agent is a containerized version of the Porter CLI that is optimized 
 This guide will show some ways to configure the Porter Agent through the [AgentConfig CRD](/operator/file-format/#agentconfig).
 
 First, let's create a new file with the AgentConfig CRD:
+
 ```yaml
 apiVersion: getporter.org/v1
 kind: AgentConfig
@@ -19,6 +20,7 @@ spec:
 ### Specifying a version
 
 By default, the Porter Agent uses the latest version from the official GitHub release. However, if you want to use a different version or a custom build hosted outside the official project, you can specify the repository and the version in the CRD. Here's an example:
+
 ```yaml
 apiVersion: getporter.org/v1
 kind: AgentConfig
@@ -32,6 +34,7 @@ spec:
 ### Configuring Access Permission
 
 In some cases, you may want to restrict access to the private registry that contains the images you need to install. With the AgentConfig CRD, you can specify two service accounts, one for the pod that runs the Agent job and another for the pod that runs the Porter installation. Here's an example:
+
 ```yaml
 apiVersion: getporter.org/v1
 kind: AgentConfig
@@ -48,8 +51,6 @@ The porter operator ships two pre-defined ClusterRole, agentconfigs-editor-role 
 
 For more information on working with private registry images, see [this section of the Porter Operator Quickstart Guide](/quickstart/#private-bundle-registries).
 
-
-
 ## Configuring Porter Plugins
 
 You can also specify any required plugins necessary for your installation of Porter. For example, if you want to use the Kubernetes and Azure plugins, you can configure the AgentConfig like this:
@@ -63,13 +64,48 @@ spec:
   pluginConfigFile:
     schemaVersion: 1.0.0
     plugins:
-        kubernetes:
-            version: v1.0.1
-        azure:
-            version: v1.0.1
-
+      kubernetes:
+        version: v1.0.1
+      azure:
+        version: v1.0.1
 ```
 
 The schema for the pluginConfigFile field is defined [in the Porter reference documentation](/reference/file-formats/#plugins).
 
 🚨 WARNING: By default, the plugin version is set to `latest`. We recommend pinning to specific version of any plugins used to avoid undesired behavior caused by a stale plugin cache. Porter currently does not expire cached installations of plugins, so installing "latest" will not pick up new versions of plugins when they are released.
+
+## Configuring Persistent Volume
+
+The AgentConfig can modify the VolumeSize that it creates as well as what StorageClassName it uses to create the volume.
+
+The VolumeSize can be specified using [CSIStorageCapacity Notation] and will result in the Persistent Volumes created by the operator having the requested capacity. When VolumeSize is not specified then a default of `64Mi` is used.
+
+The StorageClassName must resolve to the name of a StorageClass that is defined on the cluster. That StorageClass must have the following capabilities:
+
+- Supported AccessModes: ReadWriteOnce, ReadOnlyMany
+- Allow for running `chmod`
+
+When StorageClassName is not specified on the AgentConfig then the clusters default StorageClass is used. A custom StorageClass can be created by the cluster administrator and used by the operator if none of the clusters built-in StorageClasses fulfill the above requirements.
+
+You can configure the VolumeSize and StorageClassName in the AgentConfig like this:
+
+```yaml
+apiVersion: getporter.org/v1
+kind: AgentConfig
+metadata:
+  name: customAgent
+spec:
+  storageClassName: customStorageClassName
+  volumeSize: 128Mi
+```
+
+[csistoragecapacity notation]: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/csi-storage-capacity-v1/
+
+### StorageClassName Cluster Compatability Matrix
+
+This matrix will be updated as more clusters and CSI drivers are determined to be compatible
+
+| Cluster Type | Built In Compatible Driver | Cluster Version |
+| ------------ | -------------------------- | --------------- |
+| AKS          | azureblob-nfs-premium      | v1.25.4         |
+| KinD         | default                    | v1.23.4         |


### PR DESCRIPTION
# What does this change
Added ability to specify storage class name for volumes created by the Agent Config controller so that a proper storage class can be selected that supports the required capabilities 

# What issue does it fix
Closes #167 


[1]: https://getporter.org/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
Tested this in both KinD and AKS. Should extend the integration tests for the operator to test in all supported clouds

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you make any API changes? Update the corresponding API documentation.

[contributors]: https://getporter.org/src/CONTRIBUTORS.md