### PR TITLE
Only trigger the push event for the main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,9 @@
 name: build
 on:
   workflow_dispatch: {}
-  push: {}
+  push:
+    branches:
+      - "main"
   pull_request: {}
 
 jobs:


### PR DESCRIPTION
Dependabot PRs use branches that exist on the upstream repository. This is causing the push event for the build workflow to trigger but since Dependabot is not trusted, the push (build) workflow always fails due to lack of access. I've updated the push event to only trigger for the main branch to avoid the dependabot PRs always being flagged as failed.
