### PR TITLE
Build with Go 1.19.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4
 
 # Build the manager binary
-FROM golang:1.19.4 as builder
+FROM golang:1.19.7 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@
   command = "go run mage.go -v DocsDeploy"
 
   [build.environment]
-    GO_VERSION = "1.19.4"
+    GO_VERSION = "1.19.7"
 
 [context.branch-deploy]
   command = "go run mage.go -v DocsDeployPreview"


### PR DESCRIPTION
This addresses multiple CVEs identified in older versions of Go 1.17.

CVE-2022-41725
Twistlock CVE
High
go-1.19.4

CVE-2022-41724
Twistlock CVE
High
go-1.19.4

CVE-2022-41723
Twistlock CVE
High
go-1.19.4

CVE-2023-24532
Twistlock CVE
Medium
go-1.19.4

Fixes #186
