### PR TITLE
Use debian stable instead of stretch

### DIFF
--- a/installer/Dockerfile.tmpl
+++ b/installer/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # syntax=docker.io/docker/dockerfile:1.4
-FROM debian:stretch-slim
+FROM debian:stable-slim
 
 # PORTER_INIT
 


### PR DESCRIPTION
# What does this change
Update the installer base image to use Debian stable instead of the default stretch. See https://github.com/getporter/porter/issues/2744 for context. Debian stretch is archived and using stable will ensure that the image can always build.

# What issue does it fix
`mage build` fails because stretch is no longer available.

# Notes for the reviewer
N/A

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you make any API changes? Update the corresponding API documentation.

[contributors]: https://getporter.org/src/CONTRIBUTORS.md