### PR TITLE
Limit PorterConfig to namespace and system configuration 

### DIFF
--- a/api/v1/agentaction_types.go
+++ b/api/v1/agentaction_types.go
@@ -11,9 +11,6 @@ type AgentActionSpec struct {
 	// +optional
 	AgentConfig *corev1.LocalObjectReference `json:"agentConfig,omitempty"`
 
-	// PorterConfig is the name of a PorterConfig to use instead of the PorterConfig defined at the namespace or system level.
-	PorterConfig *corev1.LocalObjectReference `json:"porterConfig,omitempty"`
-
 	// Command to run inside the Porter Agent job. Defaults to running the agent.
 	Command []string `json:"command,omitempty"`
 

--- a/api/v1/credentialset_types.go
+++ b/api/v1/credentialset_types.go
@@ -34,8 +34,6 @@ type CredentialSetSpec struct {
 	// +optional
 	AgentConfig *corev1.LocalObjectReference `json:"agentConfig,omitempty" yaml:"-"`
 
-	// PorterConfig is the name of a PorterConfig to use instead of the PorterConfig defined at the namespace or system level.
-	PorterConfig *corev1.LocalObjectReference `json:"porterConfig,omitempty" yaml:"-"`
 	//
 	// These are fields from the Porter credential set resource.
 	// Your goal is that someone can copy/paste a resource from Porter into the

--- a/api/v1/credentialset_types_test.go
+++ b/api/v1/credentialset_types_test.go
@@ -48,7 +48,6 @@ func TestCredentialSetSpec_ToPorterDocument(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cs := CredentialSetSpec{
 				AgentConfig:   tt.fields.AgentConfig,
-				PorterConfig:  tt.fields.PorterConfig,
 				SchemaVersion: tt.fields.SchemaVersion,
 				Name:          tt.fields.Name,
 				Namespace:     tt.fields.Namespace,

--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -28,9 +28,6 @@ type InstallationSpec struct {
 	// +optional
 	AgentConfig *corev1.LocalObjectReference `json:"agentConfig,omitempty" yaml:"-"`
 
-	// PorterConfig is the name of a PorterConfig to use instead of the PorterConfig defined at the namespace or system level.
-	PorterConfig *corev1.LocalObjectReference `json:"porterConfig,omitempty" yaml:"-"`
-
 	//
 	// These are fields from the Porter installation resource.
 	// Your goal is that someone can copy/paste a resource from Porter into the

--- a/api/v1/parameterset_types.go
+++ b/api/v1/parameterset_types.go
@@ -35,8 +35,6 @@ type ParameterSetSpec struct {
 	// +optional
 	AgentConfig *corev1.LocalObjectReference `json:"agentConfig,omitempty" yaml:"-"`
 
-	// PorterConfig is the name of a PorterConfig to use instead of the PorterConfig defined at the namespace or system level.
-	PorterConfig *corev1.LocalObjectReference `json:"porterConfig,omitempty" yaml:"-"`
 	//
 	// These are fields from the Porter parameter set resource.
 	// Your goal is that someone can copy/paste a resource from Porter into the

--- a/api/v1/parameterset_types_test.go
+++ b/api/v1/parameterset_types_test.go
@@ -53,7 +53,6 @@ func TestParameterSetSpec_ToPorterDocument(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cs := ParameterSetSpec{
 				AgentConfig:   tt.fields.AgentConfig,
-				PorterConfig:  tt.fields.PorterConfig,
 				SchemaVersion: tt.fields.SchemaVersion,
 				Name:          tt.fields.Name,
 				Namespace:     tt.fields.Namespace,

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -78,11 +78,6 @@ func (in *AgentActionSpec) DeepCopyInto(out *AgentActionSpec) {
 		*out = new(corev1.LocalObjectReference)
 		**out = **in
 	}
-	if in.PorterConfig != nil {
-		in, out := &in.PorterConfig, &out.PorterConfig
-		*out = new(corev1.LocalObjectReference)
-		**out = **in
-	}
 	if in.Command != nil {
 		in, out := &in.Command, &out.Command
 		*out = make([]string, len(*in))
@@ -392,11 +387,6 @@ func (in *CredentialSetSpec) DeepCopyInto(out *CredentialSetSpec) {
 		*out = new(corev1.LocalObjectReference)
 		**out = **in
 	}
-	if in.PorterConfig != nil {
-		in, out := &in.PorterConfig, &out.PorterConfig
-		*out = new(corev1.LocalObjectReference)
-		**out = **in
-	}
 	if in.Credentials != nil {
 		in, out := &in.Credentials, &out.Credentials
 		*out = make([]Credential, len(*in))
@@ -509,11 +499,6 @@ func (in *InstallationSpec) DeepCopyInto(out *InstallationSpec) {
 	*out = *in
 	if in.AgentConfig != nil {
 		in, out := &in.AgentConfig, &out.AgentConfig
-		*out = new(corev1.LocalObjectReference)
-		**out = **in
-	}
-	if in.PorterConfig != nil {
-		in, out := &in.PorterConfig, &out.PorterConfig
 		*out = new(corev1.LocalObjectReference)
 		**out = **in
 	}
@@ -659,11 +644,6 @@ func (in *ParameterSetSpec) DeepCopyInto(out *ParameterSetSpec) {
 	*out = *in
 	if in.AgentConfig != nil {
 		in, out := &in.AgentConfig, &out.AgentConfig
-		*out = new(corev1.LocalObjectReference)
-		**out = **in
-	}
-	if in.PorterConfig != nil {
-		in, out := &in.PorterConfig, &out.PorterConfig
 		*out = new(corev1.LocalObjectReference)
 		**out = **in
 	}

--- a/config/crd/bases/getporter.org_agentactions.yaml
+++ b/config/crd/bases/getporter.org_agentactions.yaml
@@ -202,15 +202,6 @@ spec:
                 description: Files that should be present in the working directory
                   where the command is run.
                 type: object
-              porterConfig:
-                description: PorterConfig is the name of a PorterConfig to use instead
-                  of the PorterConfig defined at the namespace or system level.
-                properties:
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
-                    type: string
-                type: object
               volumeMounts:
                 description: VolumeMounts that should be defined on the Porter Agent
                   job.
@@ -803,7 +794,8 @@ spec:
                                         defined in spec.resourceClaims, that are used
                                         by this container. \n This is an alpha field
                                         and requires enabling the DynamicResourceAllocation
-                                        feature gate. \n This field is immutable."
+                                        feature gate. \n This field is immutable.
+                                        It can only be set for containers."
                                       items:
                                         description: ResourceClaim references one
                                           entry in PodSpec.ResourceClaims.

--- a/config/crd/bases/getporter.org_agentconfigs.yaml
+++ b/config/crd/bases/getporter.org_agentconfigs.yaml
@@ -101,9 +101,7 @@ spec:
               storageClassName:
                 description: StorageClassName is the name of the storage class that
                   Porter will request when running the Porter Agent. It is used to
-                  determine what the storage class will be for the volume requested.
-                  The storage class must support ReadWriteOnce and ReadOnlyMany access modes
-                  as well as allow for 'chmod' to be executed.
+                  determine what the storage class will be for the volume requested
                 type: string
               volumeSize:
                 description: VolumeSize is the size of the persistent volume that

--- a/config/crd/bases/getporter.org_credentialsets.yaml
+++ b/config/crd/bases/getporter.org_credentialsets.yaml
@@ -74,15 +74,6 @@ spec:
               namespace:
                 description: Namespace (in Porter) where the credential set is defined.
                 type: string
-              porterConfig:
-                description: PorterConfig is the name of a PorterConfig to use instead
-                  of the PorterConfig defined at the namespace or system level.
-                properties:
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
-                    type: string
-                type: object
               schemaVersion:
                 description: SchemaVersion is the version of the credential set state
                   schema.

--- a/config/crd/bases/getporter.org_installations.yaml
+++ b/config/crd/bases/getporter.org_installations.yaml
@@ -94,15 +94,6 @@ spec:
                   not include defaults, or values resolved from parameter sources.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
-              porterConfig:
-                description: PorterConfig is the name of a PorterConfig to use instead
-                  of the PorterConfig defined at the namespace or system level.
-                properties:
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
-                    type: string
-                type: object
               schemaVersion:
                 description: SchemaVersion is the version of the installation state
                   schema.

--- a/config/crd/bases/getporter.org_parametersets.yaml
+++ b/config/crd/bases/getporter.org_parametersets.yaml
@@ -78,15 +78,6 @@ spec:
                   - source
                   type: object
                 type: array
-              porterConfig:
-                description: PorterConfig is the name of a PorterConfig to use instead
-                  of the PorterConfig defined at the namespace or system level.
-                properties:
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
-                    type: string
-                type: object
               schemaVersion:
                 description: SchemaVersion is the version of the parameter set state
                   schema.

--- a/controllers/agentaction_controller.go
+++ b/controllers/agentaction_controller.go
@@ -589,20 +589,10 @@ func (r *AgentActionReconciler) resolvePorterConfig(ctx context.Context, log log
 	}
 	logConfig("namespace", nsCfg)
 
-	// Read agent configuration defines on the installation
-	instCfg := &porterv1.PorterConfig{}
-	if action.Spec.PorterConfig != nil {
-		err = r.Get(ctx, types.NamespacedName{Name: action.Spec.PorterConfig.Name, Namespace: action.Namespace}, instCfg)
-		if err != nil && !apierrors.IsNotFound(err) {
-			return porterv1.PorterConfigSpec{}, errors.Wrapf(err, "cannot retrieve agent configuration %s specified by the agent action", action.Spec.AgentConfig.Name)
-		}
-		logConfig("instance", instCfg)
-	}
-
 	// Resolve final configuration
 	// We don't log the final config because we haven't yet added the feature to enable not having sensitive data in porter's config files
 	base := &defaultCfg
-	cfg, err := base.MergeConfig(systemCfg.Spec, nsCfg.Spec, instCfg.Spec)
+	cfg, err := base.MergeConfig(systemCfg.Spec, nsCfg.Spec)
 	if err != nil {
 		return porterv1.PorterConfigSpec{}, err
 	}

--- a/controllers/credentialset_controller.go
+++ b/controllers/credentialset_controller.go
@@ -212,8 +212,7 @@ func newAgentAction(cs *porterv1.CredentialSet) *porterv1.AgentAction {
 			},
 		},
 		Spec: porterv1.AgentActionSpec{
-			AgentConfig:  cs.Spec.AgentConfig,
-			PorterConfig: cs.Spec.PorterConfig,
+			AgentConfig: cs.Spec.AgentConfig,
 		},
 	}
 	return action

--- a/controllers/credentialset_controller_test.go
+++ b/controllers/credentialset_controller_test.go
@@ -205,10 +205,9 @@ func TestCredentialSetReconciler_createAgentAction(t *testing.T) {
 					},
 				},
 				Spec: porterv1.CredentialSetSpec{
-					Namespace:    "dev",
-					Name:         "credset",
-					AgentConfig:  &corev1.LocalObjectReference{Name: "myAgentConfig"},
-					PorterConfig: &corev1.LocalObjectReference{Name: "myPorterConfig"},
+					Namespace:   "dev",
+					Name:        "credset",
+					AgentConfig: &corev1.LocalObjectReference{Name: "myAgentConfig"},
 				},
 			}
 			controllerutil.AddFinalizer(cs, porterv1.FinalizerName)

--- a/controllers/installation_controller.go
+++ b/controllers/installation_controller.go
@@ -223,9 +223,8 @@ func (r *InstallationReconciler) createAgentAction(ctx context.Context, log logr
 			},
 		},
 		Spec: porterv1.AgentActionSpec{
-			AgentConfig:  inst.Spec.AgentConfig,
-			PorterConfig: inst.Spec.PorterConfig,
-			Args:         []string{"installation", "apply", "installation.yaml"},
+			AgentConfig: inst.Spec.AgentConfig,
+			Args:        []string{"installation", "apply", "installation.yaml"},
 			Files: map[string][]byte{
 				"installation.yaml": installationResourceB,
 			},

--- a/controllers/installation_controller_test.go
+++ b/controllers/installation_controller_test.go
@@ -193,10 +193,9 @@ func TestInstallationReconciler_createAgentAction(t *testing.T) {
 			},
 		},
 		Spec: porterv1.InstallationSpec{
-			Namespace:    "dev",
-			Name:         "wordpress",
-			AgentConfig:  &corev1.LocalObjectReference{Name: "myAgentConfig"},
-			PorterConfig: &corev1.LocalObjectReference{Name: "myPorterConfig"},
+			Namespace:   "dev",
+			Name:        "wordpress",
+			AgentConfig: &corev1.LocalObjectReference{Name: "myAgentConfig"},
 		},
 	}
 	action, err := controller.createAgentAction(context.Background(), logr.Discard(), inst)

--- a/controllers/parameterset_controller.go
+++ b/controllers/parameterset_controller.go
@@ -265,8 +265,7 @@ func newPSAgentAction(ps *porterv1.ParameterSet) *porterv1.AgentAction {
 			},
 		},
 		Spec: porterv1.AgentActionSpec{
-			AgentConfig:  ps.Spec.AgentConfig,
-			PorterConfig: ps.Spec.PorterConfig,
+			AgentConfig: ps.Spec.AgentConfig,
 		},
 	}
 	return action

--- a/controllers/parameterset_controller_test.go
+++ b/controllers/parameterset_controller_test.go
@@ -205,10 +205,9 @@ func TestParameterSetReconciler_createAgentAction(t *testing.T) {
 					},
 				},
 				Spec: porterv1.ParameterSetSpec{
-					Namespace:    "dev",
-					Name:         "paramset",
-					AgentConfig:  &corev1.LocalObjectReference{Name: "myAgentConfig"},
-					PorterConfig: &corev1.LocalObjectReference{Name: "myPorterConfig"},
+					Namespace:   "dev",
+					Name:        "paramset",
+					AgentConfig: &corev1.LocalObjectReference{Name: "myAgentConfig"},
 				},
 			}
 			controllerutil.AddFinalizer(cs, porterv1.FinalizerName)

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -25,6 +25,6 @@ The operator is still under development, but it is ready for you to try out and 
 * [Porter Operator Glossary](/operator/glossary/)
 * [QuickStart: Using the Porter Operator](/operator/quickstart/)
 * [Porter Operator File Formats](/operator/file-formats/)
-
+* [Configure the Porter Agent]
 [porter installation apply]: /cli/porter_installations_apply/
 [Desired State QuickStart]: /quickstart/desired-state/

--- a/docs/content/administrators/configure-porter-agent.md
+++ b/docs/content/administrators/configure-porter-agent.md
@@ -1,9 +1,9 @@
 ---
-title: Configuring the Porter Agent
-description: How to customize Porter Agent
+title: Configure the Porter Agent
+description: Customize how Porter runs on Kubernetes
 ---
 
-The Porter Agent is a containerized version of the Porter CLI that is optimized for running Porter commands on a Kubernetes cluster. With the AgentConfig Custom Resource Definition (CRD), you can customize how the Porter Agent is run to meet your specific needs and requirements. For example, you can specify the version of Porter to use, install additional Porter plugins, or provide a custom Porter config file.
+The [Porter Agent] is a containerized version of the Porter CLI that is optimized for running Porter commands on a Kubernetes cluster. With the AgentConfig Custom Resource Definition (CRD), you can customize how the Porter Agent is run to meet your specific needs and requirements. For example, you can specify the version of Porter to use, install additional Porter plugins, or provide a custom Porter config file.
 
 This guide will show some ways to configure the Porter Agent through the [AgentConfig CRD](/operator/file-format/#agentconfig).
 
@@ -109,3 +109,5 @@ This matrix will be updated as more clusters and CSI drivers are determined to b
 | ------------ | -------------------------- | --------------- |
 | AKS          | azureblob-nfs-premium      | v1.25.4         |
 | KinD         | default                    | v1.23.4         |
+
+[Porter Agent]: /operator/glossary/#porter-agent

--- a/docs/content/file-formats.md
+++ b/docs/content/file-formats.md
@@ -28,7 +28,6 @@ In addition to the normal fields available on a [Porter Installation document](/
 | Field        | Required | Default                             | Description                                                 |
 |--------------|----------|-------------------------------------|-------------------------------------------------------------|
 | agentConfig  | false    | See [Agent Config](#agentconfig)   | Reference to an AgentConfig resource in the same namespace. |
-| porterConfig | false    | See [Porter Config](#porterconfig) | Reference to a PorterConfig resource in the same namespace. |
 
 [Installation]: /operator/glossary/#installation
 
@@ -59,7 +58,6 @@ spec:
 | Field                     | Required | Default                            | Description                                                 |
 |---------------------------|----------|------------------------------------|-------------------------------------------------------------|
 | agentConfig               | false    | See [Agent Config](#agentconfig)   | Reference to an AgentConfig resource in the same namespace. |
-| porterConfig              | false    | See [Porter Config](#porterconfig) | Reference to a PorterConfig resource in the same namespace. |
 | credentials               | true     |                                    | List of credential sources for the set |
 | credentials.name          | true     |                                    | The name of the credential for the bundle |
 | credentials.source        | true     |                                    | The credential type. Currently `secret` is the only supported source |
@@ -98,7 +96,6 @@ spec:
 | Field                     | Required | Default                            | Description                                                 |
 |---------------------------|----------|------------------------------------|-------------------------------------------------------------|
 | agentConfig               | false    | See [Agent Config](#agentconfig)   | Reference to an AgentConfig resource in the same namespace. |
-| porterConfig              | false    | See [Porter Config](#porterconfig) | Reference to a PorterConfig resource in the same namespace. |
 | parameters                | true     |                                    | List of parameter sources for the set |
 | parameters.name           | true     |                                    | The name of the parameter for the bundle |
 | parameters.source         | true     |                                    | The parameters type. Currently `vaule` and `secret` are the only supported sources |
@@ -126,7 +123,6 @@ spec:
 | Field        | Required | Default                                | Description                                                                                                                           |
 |--------------|----------|----------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
 | agentConfig  | false    | See [Agent Config](#agentconfig)       | Reference to an AgentConfig resource in the same namespace.                                                                           |
-| porterConfig | false    | See [Porter Config](#porterconfig)     | Reference to a PorterConfig resource in the same namespace.                                                                           |
 | command      | false    | /app/.porter/agent                     | Overrides the entrypoint of the Porter Agent image.                                                                                   |
 | args         | true     | None.                                  | Arguments to pass to the porter command. Do not include "porter" in the arguments. For example, use ["help"], not ["porter", "help"]. |
 | files        | false    | None.                                  | Files that should be present in the working directory where the command is run.                                                       |

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -111,7 +111,7 @@ porter invoke porterops --action configureNamespace --param namespace=TODO -c po
 * A PorterConfig resource named default is created in the specified namespace configuring Porter to use
   the kubernetes.secrets and mongodb plugin.
 
-# Configuration
+## Configuration
 
 The bundle accepts a parameter, porterConfig, that should be a YAML-formatted [Porter configuration file](/configuration/).
 
@@ -149,10 +149,15 @@ The bundle also has parameters defined that control how the [Porter Agent] is co
 | volumeSize  | Size of the volume shared between Porter and the bundles it executes.<br/><br/>Defaults to 64Mi.  |
 
 
-# Inspect the installation
+## Inspect the installation
 
 You can use the porter CLI to query and interact with installations created by the operator.
 Follow the instructions in [Connect to the in-cluster mongo database][connect] to point porter at the Mongodb server that was installed with the operator.
 
+## Next Steps
+
+* [Configure the Porter Agent](/operator/administrators/configure-porter-agent.md)
+
 [install-porter]: https://github.com/getporter/porter/releases?q=v1.0.0&expanded=true
 [Porter Agent]: /operator/glossary/#porter-agent
+

--- a/mage/env.go
+++ b/mage/env.go
@@ -3,9 +3,6 @@ package mage
 import (
 	"os"
 	"path"
-
-	"github.com/carolynvs/magex/mgx"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -34,7 +31,7 @@ func getAmbientEnvironment() Environment {
 	default:
 		registry := os.Getenv("PORTER_OPERATOR_REGISTRY")
 		if registry == "" {
-			mgx.Must(errors.New("environment variable PORTER_OPERATOR_REGISTRY must be set to push to a custom registry"))
+			registry = "localhost:5000"
 		}
 		return buildEnvironment(name, registry)
 	}


### PR DESCRIPTION
# What does this change
Remove the PorterConfig setting from individual resources so that the PorterConfig within any namespace is constant. This allows us to run a porter data service in each namespace and safely work with any resources defined in that namespace.

# What issue does it fix
Fixes #154

# Notes for the reviewer
I was running into build errors because PORTER_OPERATOR_REGISTRY was not set, it really shouldn't be required just to do a build, so I defaulted it to the local registry that mage sets up when it runs the tests, localhost:5000.

# Checklist
- [ ] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you make any API changes? Update the corresponding API documentation.

[contributors]: https://getporter.org/src/CONTRIBUTORS.md