### PR TITLE
169 porter operator manager unable to create agent actions if agent config is overwritten

### DIFF
--- a/controllers/agentconfig_controller.go
+++ b/controllers/agentconfig_controller.go
@@ -191,8 +191,12 @@ func (r *AgentConfigReconciler) createEmptyPluginVolume(ctx context.Context, log
 	if err != nil {
 		return nil, false, err
 	}
-
-	if pluginPVC != nil || tempPVC != nil {
+	// If there is an exising claim then return it. This can be either the pluginPVC or a tempPVC depending on where in the process
+	// we are. If the final plugin PVC exists then return that otherwise return the temp one.
+	if pluginPVC != nil {
+		return pluginPVC, false, nil
+	}
+	if tempPVC != nil {
 		return tempPVC, false, nil
 	}
 

--- a/tests/integration/agentconfig_test.go
+++ b/tests/integration/agentconfig_test.go
@@ -72,7 +72,7 @@ var _ = Describe("AgentConfig delete", func() {
 var _ = Describe("AgentConfig update", func() {
 	Context("when an existing AgentConfig is updated", func() {
 		It("should update the plugin volumes associated with the AgentConfig", func() {
-			By("creating an agent action", func() {
+			By("creating an agent action each time the config is updated", func() {
 				ctx := context.Background()
 				ns := createTestNamespace(ctx)
 

--- a/tests/integration/agentconfig_test.go
+++ b/tests/integration/agentconfig_test.go
@@ -33,12 +33,7 @@ var _ = Describe("AgentConfig delete", func() {
 				Expect(len(agentCfg.Spec.Plugins.GetNames())).To(Equal(1))
 
 				Log("verify it's created")
-				jsonOut := runAgentAction(ctx, "create-check-plugins-list", ns, agentCfg.Name, []string{"plugins", "list", "-o", "json"})
-				firstName := gjson.Get(jsonOut, "0.name").String()
-				numPluginsInstalled := gjson.Get(jsonOut, "#").Int()
-				Expect(int64(1)).To(Equal(numPluginsInstalled))
-				_, ok := agentCfg.Spec.Plugins.GetByName(firstName)
-				Expect(ok).To(BeTrue())
+				verifyAgentConfigPlugins(ctx, agentCfg, "create-check-plugins-list")
 
 				Log("verify retry limit is correctly set")
 				job, err := getAgentActionJob(ctx, "create-check-plugins-list", ns)
@@ -90,36 +85,89 @@ var _ = Describe("AgentConfig update", func() {
 				Expect(len(agentCfg.Spec.Plugins.GetNames())).To(Equal(1))
 
 				Log("verify it's created")
-				jsonOut := runAgentAction(ctx, "create-check-plugins-list", ns, agentCfg.Name, []string{"plugins", "list", "-o", "json"})
-				firstName := gjson.Get(jsonOut, "0.name").String()
-				numPluginsInstalled := gjson.Get(jsonOut, "#").Int()
-				Expect(int64(1)).To(Equal(numPluginsInstalled))
-				_, ok := agentCfg.Spec.Plugins.GetByName(firstName)
-				Expect(ok).To(BeTrue())
+				verifyAgentConfigPlugins(ctx, agentCfg, "create-check-plugins-list")
 
 				// Update the AgentConfig and patch it
-				patchAC := func(ac *porterv1.AgentConfig) {
-					controllers.PatchObjectWithRetry(ctx, logr.Discard(), k8sClient, k8sClient.Patch, ac, func() client.Object {
+				patchAC := func(ac *porterv1.AgentConfig) error {
+					return controllers.PatchObjectWithRetry(ctx, logr.Discard(), k8sClient, k8sClient.Patch, ac, func() client.Object {
 						return &porterv1.AgentConfig{}
 					})
 				}
-				agentCfg.AgentConfig.Spec.PluginConfigFile.Plugins = map[string]porterv1.Plugin{"azure": {}}
-				patchAC(&agentCfg.AgentConfig)
+				k8sClient.Get(ctx, client.ObjectKeyFromObject(&agentCfg.AgentConfig), &agentCfg.AgentConfig)
+				// Update the plugins
+				agentCfg.AgentConfig.Spec.PluginConfigFile = &porterv1.PluginFileSpec{
+					SchemaVersion: "1.0.0",
+					Plugins: map[string]porterv1.Plugin{
+						"azure": {},
+					},
+				}
+				agentCfg.Spec = porterv1.NewAgentConfigSpecAdapter(agentCfg.AgentConfig.Spec)
+				Expect(patchAC(&agentCfg.AgentConfig)).Should(Succeed())
 				// Verify that the new job is created
 				Expect(waitForPorter(ctx, &agentCfg.AgentConfig, 2, "waiting for agent config to update")).Should(Succeed())
-				// Verify that the AgentConfig reports as "ready"
 				validateResourceConditions(agentCfg)
 				Expect(len(agentCfg.Spec.Plugins.GetNames())).To(Equal(1))
-				// Verify that the AgentConfig can be used by an installation
+				// Verify its been updated
+				Log("verify it's updated")
+				verifyAgentConfigPlugins(ctx, agentCfg, "update-check-plugins-list")
+				// Verify that the AgentConfig is ready
+				k8sClient.Get(ctx, client.ObjectKeyFromObject(&agentCfg.AgentConfig), &agentCfg.AgentConfig)
+				Expect(agentCfg.AgentConfig.Status.Ready).To(BeTrue())
+
+				// Update a spec value outside of the plugins
+				agentCfg.AgentConfig.Spec.VolumeSize = "50M"
+				agentCfg.Spec = porterv1.NewAgentConfigSpecAdapter(agentCfg.AgentConfig.Spec)
+				Expect(patchAC(&agentCfg.AgentConfig)).Should(Succeed())
+				// Verify that the new job is created
+				Expect(waitForPorter(ctx, &agentCfg.AgentConfig, 3, "waiting for agent config to update")).Should(Succeed())
+				validateResourceConditions(agentCfg)
+				Expect(len(agentCfg.Spec.Plugins.GetNames())).To(Equal(1))
+				// Verify the plugins are the same
+				Log("verify it's updated")
+				verifyAgentConfigPlugins(ctx, agentCfg, "update-check-plugins-list-2")
+				// Verify that the AgentConfig is ready
+				k8sClient.Get(ctx, client.ObjectKeyFromObject(&agentCfg.AgentConfig), &agentCfg.AgentConfig)
+				Expect(agentCfg.AgentConfig.Status.Ready).To(BeTrue())
+				Expect(agentCfg.AgentConfig.Spec.VolumeSize).To(Equal("50M"))
+
+				// Revert back to a previously installed plugin
+				agentCfg.AgentConfig.Spec.PluginConfigFile = &porterv1.PluginFileSpec{
+					SchemaVersion: "1.0.0",
+					Plugins: map[string]porterv1.Plugin{
+						"kubernetes": {},
+					},
+				}
+				agentCfg.Spec = porterv1.NewAgentConfigSpecAdapter(agentCfg.AgentConfig.Spec)
+				Expect(patchAC(&agentCfg.AgentConfig)).Should(Succeed())
+				// Verify that the new job is created
+				Expect(waitForPorter(ctx, &agentCfg.AgentConfig, 4, "waiting for agent config to update")).Should(Succeed())
+				validateResourceConditions(agentCfg)
+				Expect(len(agentCfg.Spec.Plugins.GetNames())).To(Equal(1))
+				// Verify its been updated
+				Log("verify it's updated")
+				verifyAgentConfigPlugins(ctx, agentCfg, "revert-check-plugins-list")
+				// Verify that the AgentConfig is ready
+				k8sClient.Get(ctx, client.ObjectKeyFromObject(&agentCfg.AgentConfig), &agentCfg.AgentConfig)
+				Expect(agentCfg.AgentConfig.Status.Ready).To(BeTrue())
+
 			})
 		})
 	})
 })
 
+func verifyAgentConfigPlugins(ctx context.Context, agentCfg *porterv1.AgentConfigAdapter, actionName string) {
+	jsonOut := runAgentAction(ctx, actionName, agentCfg.Namespace, agentCfg.Name, []string{"plugins", "list", "-o", "json"})
+	firstName := gjson.Get(jsonOut, "0.name").String()
+	numPluginsInstalled := gjson.Get(jsonOut, "#").Int()
+	Expect(int64(1)).To(Equal(numPluginsInstalled))
+	_, ok := agentCfg.Spec.Plugins.GetByName(firstName)
+	Expect(ok).To(BeTrue())
+}
+
 // NewTestAgentCfg minimal AgentConfig CRD for tests
 func NewTestAgentCfg() *porterv1.AgentConfigAdapter {
 	var retryLimit int32 = 2
-	cs := porterv1.AgentConfig{
+	ac := porterv1.AgentConfig{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "getporter.org/v1",
 			Kind:       "AgentConfig",
@@ -137,5 +185,5 @@ func NewTestAgentCfg() *porterv1.AgentConfigAdapter {
 			},
 		},
 	}
-	return porterv1.NewAgentConfigAdapter(cs)
+	return porterv1.NewAgentConfigAdapter(ac)
 }


### PR DESCRIPTION
# What does this change
Previously when a volume existed that already satisfied the agent config plugins hash we would only return the temp volume claim. In this scenario however the temp volume claim can have already been deleted so we would return "nil" when we found a ready volume claim only. 

Now the ready volume claim is returned if its found, otherwise the temp claim is returned if its found, or finally a new empty one is created.

# What issue does it fix
Closes #169 

[1]: https://getporter.org/src/CONTRIBUTING.md#when-to-open-a-pull-request

# Notes for the reviewer
_Put any questions or notes for the reviewer here._
renamePluginVolume handles reconciling if the volume claim is the ready or temp claim. This scenario is just for resolving at action create time if a final claim (ready) exists, a temp claim exists, or if a new claim needs to be created.

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you make any API changes? Update the corresponding API documentation.

[contributors]: https://getporter.org/src/CONTRIBUTORS.md