### PR TITLE
Create tests for method `renamePluginVolume`

### DIFF
--- a/controllers/agentconfig_controller.go
+++ b/controllers/agentconfig_controller.go
@@ -584,7 +584,7 @@ func (r *AgentConfigReconciler) isReadyToBeDeleted(ctx context.Context, log logr
 func (r *AgentConfigReconciler) getExistingPluginPVCs(ctx context.Context, log logr.Logger, agentCfg *porterv1.AgentConfigAdapter) (readyPVC *corev1.PersistentVolumeClaim, tempPVC *corev1.PersistentVolumeClaim, err error) {
 	results := &corev1.PersistentVolumeClaimList{}
 	err = r.List(ctx, results, client.InNamespace(agentCfg.Namespace), client.MatchingLabels(agentCfg.Spec.Plugins.GetLabels()))
-	if err != nil && !apierrors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) || len(results.Items) < 1 {
 		return nil, nil, err
 	}
 	hashedName := agentCfg.Spec.Plugins.GetPVCName(agentCfg.Namespace)

--- a/controllers/agentconfig_controller.go
+++ b/controllers/agentconfig_controller.go
@@ -375,16 +375,12 @@ func definePluginVomeAndMount(pvc *corev1.PersistentVolumeClaim) (corev1.Volume,
 
 // createHashPVC creates a new pvc using the hash of all plugins metadata.
 // It uses the label selector to make sure we will select the volum that has plugins installed.
-func (r *AgentConfigReconciler) createHashPVC(
-	ctx context.Context,
-	log logr.Logger,
-	agentCfg *porterv1.AgentConfigAdapter,
+func (r *AgentConfigReconciler) createHashPVC(ctx context.Context, log logr.Logger, agentCfg *porterv1.AgentConfigAdapter,
 ) (*corev1.PersistentVolumeClaim, error) {
 	log.V(Log4Debug).Info("Creating new pvc using the hash of all plugins metadata", "new persistentvolumeclaim", agentCfg.GetPluginsPVCName())
 	labels := agentCfg.Spec.Plugins.GetLabels()
 	labels[porterv1.LabelResourceName] = agentCfg.Name
 	storageClassName := agentCfg.Spec.GetStorageClassName()
-
 	selector := &metav1.LabelSelector{
 		MatchLabels: labels,
 	}
@@ -591,7 +587,6 @@ func (r *AgentConfigReconciler) getExistingPluginPVCs(ctx context.Context, log l
 	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, nil, err
 	}
-
 	hashedName := agentCfg.Spec.Plugins.GetPVCName(agentCfg.Namespace)
 	for _, item := range results.Items {
 		item := item
@@ -713,7 +708,7 @@ func (r *AgentConfigReconciler) syncPluginInstallStatus(ctx context.Context, log
 
 func (r *AgentConfigReconciler) renamePluginVolume(ctx context.Context, log logr.Logger, action *porterv1.AgentAction, agentCfg *porterv1.AgentConfigAdapter) error {
 	// if the plugin install action is not finished, we need to wait for it before acting further
-	if !(apimeta.IsStatusConditionTrue(action.Status.Conditions, string(porterv1.ConditionComplete)) && action.Status.Phase == porterv1.PhaseSucceeded) {
+	if !apimeta.IsStatusConditionTrue(action.Status.Conditions, string(porterv1.ConditionComplete)) && action.Status.Phase != porterv1.PhaseSucceeded {
 		log.V(Log4Debug).Info("Plugins is not ready yet.", "action status", action.Status)
 		return nil
 	}

--- a/controllers/agentconfig_controller_test.go
+++ b/controllers/agentconfig_controller_test.go
@@ -723,6 +723,58 @@ func TestAgentConfigReconciler_createAgentAction(t *testing.T) {
 	assert.Equal(t, action.Spec.VolumeMounts[0].SubPath, "plugins", "incorrect VolumeMounts")
 }
 
+func TestRenamePluginVolume(t *testing.T) {
+	tests := map[string]struct {
+		actionCondition metav1.ConditionStatus
+		phase           porterv1.AgentPhase
+		pvc             *corev1.PersistentVolumeClaim
+	}{
+		"phase-pending":   {actionCondition: metav1.ConditionFalse, phase: porterv1.PhasePending},
+		"phase-running":   {actionCondition: metav1.ConditionFalse, phase: porterv1.PhaseRunning},
+		"phase-succeeded": {actionCondition: metav1.ConditionTrue, phase: porterv1.PhaseSucceeded, pvc: &corev1.PersistentVolumeClaim{}},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			action := &porterv1.AgentAction{
+				Status: porterv1.AgentActionStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(porterv1.ConditionComplete),
+							Status: test.actionCondition,
+						},
+					},
+					Phase: test.phase,
+				},
+			}
+			spec := porterv1.AgentConfigSpec{
+				StorageClassName: "fake-storageclass",
+				PluginConfigFile: &porterv1.PluginFileSpec{Plugins: map[string]porterv1.Plugin{"kubernetes": {}}},
+			}
+			actionspec := porterv1.NewAgentConfigSpecAdapter(spec)
+			actionCfg := &porterv1.AgentConfigAdapter{
+				AgentConfig: porterv1.AgentConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "fake-name",
+						Namespace: "fake-namespace",
+					},
+				},
+				Spec: actionspec,
+			}
+			logger := logr.Discard()
+			r := &AgentConfigReconciler{}
+			if test.pvc != nil {
+				r = setupAgentConfigController(test.pvc)
+			} else {
+
+				r = setupAgentConfigController()
+			}
+
+			err := r.renamePluginVolume(context.TODO(), logger, action, actionCfg)
+			assert.NoError(t, err)
+		})
+	}
+}
+
 func setupAgentConfigController(objs ...client.Object) *AgentConfigReconciler {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))

--- a/controllers/agentconfig_controller_test.go
+++ b/controllers/agentconfig_controller_test.go
@@ -761,7 +761,7 @@ func TestRenamePluginVolume(t *testing.T) {
 				Spec: actionspec,
 			}
 			logger := logr.Discard()
-			r := &AgentConfigReconciler{}
+			var r *AgentConfigReconciler
 			if test.pvc != nil {
 				r = setupAgentConfigController(test.pvc)
 			} else {


### PR DESCRIPTION
# What does this change
- [x] Add tests for method `renamePluginVolume` 
- [x] Fixes linter nits 


# What issue does it fix
No issue to close but improves the testing posture of this controller. 

# Notes for the reviewer

During adding these tests, there is a condition I believe we are not checking for.  If the list of PVCs returned length is < 1 we still continue to return the `readyPVC, tempPVC, nil` (`r.getExistingPluginPVCs(...)`).  There is a no-op check there for the items list but we are returning:

```go
   return readyPVC, tempPVC, nil
```
even if the list (which doesn't error, because you can return an empty list) results.Items < 1.  Not sure what behavior we want from this but guarding against that was noted during testing this method. If we do want to make sure that we always get a list > 1 from that method, I can update this PR to modify that.  


# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation?
     - No, it's not needed for adding tests 
- [ ] Did you make any API changes? Update the corresponding API documentation.
     - No, no changes to the API was made

[contributors]: https://getporter.org/src/CONTRIBUTORS.md