### PR TITLE
fix printer columns

### DIFF
--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -113,11 +113,10 @@ type InstallationStatus struct {
 // +kubebuilder:subresource:status
 
 // Installation is the Schema for the installations API
-// +kubebuilder:printcolumn:name="Namespace",type="string",JSONPath=".metadata.Namespace"
-// +kubebuilder:printcolumn:name="Porter Namespace",type="string",JSONPath=".spec.Namespace"
-// +kubebuilder:printcolumn:name="Name",type="string",JSONPath=".spec.Name"
-// +kubebuilder:printcolumn:name="Last Action",type="string",JSONPath=".status.PorterResourceStatus.Action"
-// +kubebuilder:printcolumn:name="Last Status",type="string",JSONPath=".status.PorterResourceStatus.Phase"
+// +kubebuilder:printcolumn:name="Porter Name",type="string",JSONPath=".spec.name"
+// +kubebuilder:printcolumn:name="Porter Namespace",type="string",JSONPath=".spec.namespace"
+// +kubebuilder:printcolumn:name="Last Action",type="string",JSONPath=".status.action.name"
+// +kubebuilder:printcolumn:name="Last Status",type="string",JSONPath=".status.phase"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type Installation struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/config/crd/bases/getporter.org_installations.yaml
+++ b/config/crd/bases/getporter.org_installations.yaml
@@ -16,19 +16,16 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .metadata.Namespace
-      name: Namespace
+    - jsonPath: .spec.name
+      name: Porter Name
       type: string
-    - jsonPath: .spec.Namespace
+    - jsonPath: .spec.namespace
       name: Porter Namespace
       type: string
-    - jsonPath: .spec.Name
-      name: Name
-      type: string
-    - jsonPath: .status.PorterResourceStatus.Action
+    - jsonPath: .status.action.name
       name: Last Action
       type: string
-    - jsonPath: .status.PorterResourceStatus.Phase
+    - jsonPath: .status.phase
       name: Last Status
       type: string
     - jsonPath: .metadata.creationTimestamp


### PR DESCRIPTION
# What does this change
Printer columns were printing out like this:
```python
NAME                            PORTER NAME    PORTER NAMESPACE   LAST ACTION     LAST STATUS   AGE
test-install-1691504789-nf9k2                                                                 6h39m
```
Now they print out like this:
```python
NAME                            PORTER NAME               PORTER NAMESPACE   LAST ACTION                           LAST STATUS   AGE
test-install-1691504789-nf9k2   test-install-1691504789   demo               test-install-1691504789-nf9k2-gnfm7   Succeeded     6h39m
```
The capital letters in the printcolumns kubebuilder annotation didn't allow them to be printed properly

# What issue does it fix

No issue filed

# Notes for the reviewer
`None`

# Checklist
- [ ] Did you write tests?
     - [x] No, demonstrated with output
- [ ] Did you write documentation?
- [ ] Did you make any API changes? Update the corresponding API documentation.

