### PR TITLE
Fix installation docs

### DIFF
--- a/docs/content/quickstart/_index.md
+++ b/docs/content/quickstart/_index.md
@@ -12,7 +12,7 @@ In this QuickStart you will learn how to install and use the [Porter Operator] o
 
 * [Install the most recent Porter v1 prerelease][install-porter]
 * Docker, either a local installation or a remote Docker Host.
-* A Kubernetes cluster. [KinD] or [Minikube] work well but follow the links for required configuration.
+* A Kubernetes cluster. [KinD][configure-kind] or [Minikube][configure-minikube] work well but follow the links for required configuration.
 * kubectl, with its kubeconfig configured to use the cluster.
 
 ## Install the Operator
@@ -345,4 +345,6 @@ You now know how to install and configure the Porter Operator. The project is st
 [install-porter]: https://github.com/getporter/porter/releases?q=v1.0.0&expanded=true
 [KinD]: /best-practices/kind/
 [Minikube]: /best-practices/minikube/
+[configure-kind]: https://github.com/getporter/porter/blob/main/docs/content/docs/integrations/kind.md
+[configure-minikube]: https://github.com/getporter/porter/blob/main/docs/content/docs/integrations/minikube.md
 [getporter/hello-llama]: https://hub.docker.com/r/getporter/hello-llama


### PR DESCRIPTION
# What does this change
This change updates the docs for installing the operator on a kubernetes cluster using porter bundles. Kind and minikube clusters need to be configured a certain way in order to accept kubectl connections from within porter bundles.

# What issue does it fix
https://github.com/getporter/kubernetes-mixin/issues/54
https://github.com/getporter/operator/issues/263

# Checklist
- [ ] Did you write tests?
- [x] Did you write documentation?
- [ ] Did you make any API changes? Update the corresponding API documentation.

[contributors]: https://getporter.org/src/CONTRIBUTORS.md