### PR TITLE
Utilize the Recorder to create events with installation resources

### DIFF
--- a/controllers/installation_controller.go
+++ b/controllers/installation_controller.go
@@ -176,6 +176,7 @@ func (r *InstallationReconciler) CheckOrCreateInstallationOutputsCR(ctx context.
 			if err != nil {
 				log.V(Log4Debug).Info(fmt.Sprintf("failed to get output from grpc server for: %s:%s installation error: %s", inst.Spec.Name, inst.Spec.Namespace, err.Error()))
 				// NOTE: Stop installation output cr creation
+				r.Recorder.Event(inst, "Warning", "CreatingInstallationOutputs", fmt.Sprintf("created installation outputs failed for %s", inst.Name))
 				return ctrl.Result{}, nil
 			}
 			// TODO: Separate this into it's own func to test and extract what you
@@ -202,6 +203,7 @@ func (r *InstallationReconciler) CheckOrCreateInstallationOutputsCR(ctx context.
 			if err != nil {
 				return ctrl.Result{}, err
 			}
+			r.Recorder.Event(inst, "Normal", "CreatingInstallationOutputs", fmt.Sprintf("created installation outputs for %s", inst.Name))
 			log.V(Log5Trace).Info("successfully created outputs cr")
 			patchInstall := client.MergeFrom(inst.DeepCopy())
 			inst.SetAnnotations(map[string]string{v1.AnnotationInstallationOutput: "true"})
@@ -352,6 +354,7 @@ func (r *InstallationReconciler) createAgentAction(ctx context.Context, log logr
 		return nil, errors.Wrap(err, "error creating the porter agent action")
 	}
 
+	r.Recorder.Event(inst, "Normal", "CreateAgentAction", fmt.Sprintf("created installation agent action for %s", inst.Name))
 	log.V(Log4Debug).Info("Created porter agent action", "name", action.Name)
 	return action, nil
 }

--- a/controllers/installation_controller.go
+++ b/controllers/installation_controller.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -32,6 +33,7 @@ type InstallationReconciler struct {
 	client.Client
 	Log              logr.Logger
 	PorterGRPCClient PorterClient
+	Recorder         record.EventRecorder
 	Scheme           *runtime.Scheme
 }
 

--- a/controllers/installation_controller.go
+++ b/controllers/installation_controller.go
@@ -194,6 +194,7 @@ func (r *InstallationReconciler) CheckOrCreateInstallationOutputsCR(ctx context.
 			if err != nil {
 				return ctrl.Result{}, err
 			}
+			r.Recorder.Event(inst, "Normal", "CreatingInstallationOutputs", fmt.Sprintf("created installation outputs for %s", inst.Name))
 			installOutputs, err := r.CreateStatusOutputs(ctx, outputs, resp)
 			if err != nil {
 				return ctrl.Result{}, err
@@ -203,7 +204,6 @@ func (r *InstallationReconciler) CheckOrCreateInstallationOutputsCR(ctx context.
 			if err != nil {
 				return ctrl.Result{}, err
 			}
-			r.Recorder.Event(inst, "Normal", "CreatingInstallationOutputs", fmt.Sprintf("created installation outputs for %s", inst.Name))
 			log.V(Log5Trace).Info("successfully created outputs cr")
 			patchInstall := client.MergeFrom(inst.DeepCopy())
 			inst.SetAnnotations(map[string]string{v1.AnnotationInstallationOutput: "true"})

--- a/controllers/installation_controller_test.go
+++ b/controllers/installation_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -468,8 +469,9 @@ func setupInstallationController(objs ...client.Object) *InstallationReconciler 
 	fakeClient := fakeBuilder.Build()
 
 	return &InstallationReconciler{
-		Log:    logr.Discard(),
-		Client: fakeClient,
-		Scheme: scheme,
+		Log:      logr.Discard(),
+		Client:   fakeClient,
+		Recorder: record.NewFakeRecorder(42),
+		Scheme:   scheme,
 	}
 }

--- a/controllers/parameterset_controller_test.go
+++ b/controllers/parameterset_controller_test.go
@@ -256,6 +256,19 @@ func TestParameterSetReconciler_createAgentAction(t *testing.T) {
 	}
 }
 
+func TestRemoveParamSetFinalizer(t *testing.T) {
+	ctx := context.Background()
+	ps := &porterv1.ParameterSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fake-install",
+			Namespace: "fake-ns",
+		},
+	}
+	client := setupParameterSetController(ps)
+
+	removeParamSetFinalizer(ctx, logr.Discard(), client.Client, ps)
+}
+
 func setupParameterSetController(objs ...client.Object) ParameterSetReconciler {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))

--- a/controllers/parameterset_controller_test.go
+++ b/controllers/parameterset_controller_test.go
@@ -266,7 +266,8 @@ func TestRemoveParamSetFinalizer(t *testing.T) {
 	}
 	client := setupParameterSetController(ps)
 
-	removeParamSetFinalizer(ctx, logr.Discard(), client.Client, ps)
+	err := removeParamSetFinalizer(ctx, logr.Discard(), client.Client, ps)
+	assert.NoError(t, err)
 }
 
 func setupParameterSetController(objs ...client.Object) ParameterSetReconciler {

--- a/controllers/porter_resource_test.go
+++ b/controllers/porter_resource_test.go
@@ -1,9 +1,11 @@
 package controllers
 
 import (
+	"context"
 	"testing"
 
 	porterv1 "get.porter.sh/operator/api/v1"
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -119,4 +121,18 @@ func Test_isFinalizerSet(t *testing.T) {
 
 	inst.Finalizers = append(inst.Finalizers, porterv1.FinalizerName)
 	assert.True(t, isFinalizerSet(inst))
+}
+
+func TestRemoveFinalizer(t *testing.T) {
+	ctx := context.Background()
+	inst := &porterv1.Installation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fake-installation",
+			Namespace: "default",
+		},
+	}
+	client := setupInstallationController(inst)
+
+	err := removeFinalizer(ctx, logr.Discard(), client.Client, inst)
+	assert.NoError(t, err)
 }

--- a/main.go
+++ b/main.go
@@ -79,6 +79,7 @@ func main() {
 	if err = (&controllers.InstallationReconciler{
 		Client:           mgr.GetClient(),
 		PorterGRPCClient: client,
+		Recorder:         mgr.GetEventRecorderFor("installation"),
 		Log:              ctrl.Log.WithName("controllers").WithName("Installation"),
 		Scheme:           mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {

--- a/tests/integration/suite_test.go
+++ b/tests/integration/suite_test.go
@@ -70,9 +70,10 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&controllers.InstallationReconciler{
-		Client: k8sManager.GetClient(),
-		Scheme: scheme.Scheme,
-		Log:    ctrl.Log.WithName("controllers").WithName("Installation"),
+		Client:   k8sManager.GetClient(),
+		Scheme:   scheme.Scheme,
+		Recorder: k8sManager.GetEventRecorderFor("installation"),
+		Log:      ctrl.Log.WithName("controllers").WithName("Installation"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
# What does this change
Adds events to the installation controller when installation outputs get created and/or finish reconciling 

# What issue does it fix
It doesn't.  It helps the user see events in the k8s context. 

# Notes for the reviewer
_Slight enhancement but nothing to 😍 about_

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you make any API changes? Update the corresponding API documentation.
