### PR TITLE
Add deletion policy annotation on all installations 

### DIFF
--- a/api/v1/installation_types.go
+++ b/api/v1/installation_types.go
@@ -11,8 +11,11 @@ import (
 )
 
 const (
-	Prefix          = "getporter.org/"
-	AnnotationRetry = Prefix + "retry"
+	Prefix                       = "getporter.org/"
+	AnnotationRetry              = Prefix + "retry"
+	PorterDeletePolicyAnnotation = "getporter.org/deletion-policy"
+	PorterDeletePolicyDelete     = "delete"
+	PorterDeletePolicyOrphan     = "orphan"
 )
 
 // We marshal installation spec to yaml when converting to a porter object


### PR DESCRIPTION
# What does this change
This will add the annotation that we will use to determine how we **want** to delete the resources (installations and otherwise) to adopt the pattern from cross-plane as noted in issue #297 

_~~This is still in draft~~_

All this does is just add the annotation, the WIP will use this to implement the logic behind this new annotation.

# What issue does it fix
Partially closes #297 

# Notes for the reviewer
_Put any questions or notes for the reviewer here._

# Checklist
- [x] Did you write tests?
- [ ] Did you write documentation? _maybe?_ public facing for sure.
- [ ] Did you make any API changes? Update the corresponding API documentation. _none_

[contributors]: https://getporter.org/src/CONTRIBUTORS.md