### PR TITLE
Calculate the version correctly when releasing from tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ replace (
 )
 
 require (
-	get.porter.sh/magefiles v0.6.3
+	get.porter.sh/magefiles v0.6.8
 	get.porter.sh/porter v1.0.17
 	github.com/carolynvs/aferox v0.3.0
 	github.com/carolynvs/magex v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqCl
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-get.porter.sh/magefiles v0.6.3 h1:OE9YqCArn9fvM+VdanGlXNyIjy2F8W4yJGy5kcC/xD0=
-get.porter.sh/magefiles v0.6.3/go.mod h1:w37oTKICvvaEKR5KVB9UfN2EX30uYO9Qk0oRoz80DOU=
+get.porter.sh/magefiles v0.6.8 h1:1q0CmKgOtlP8IBXtRNLv2+r9tLiC96tpIPhTHX+HlUw=
+get.porter.sh/magefiles v0.6.8/go.mod h1:w37oTKICvvaEKR5KVB9UfN2EX30uYO9Qk0oRoz80DOU=
 get.porter.sh/porter v1.0.17 h1:x827yJ4VUsYLL8glC8GUZq+gycme1gYtvu/viyH1S+g=
 get.porter.sh/porter v1.0.17/go.mod h1:NtSW1T0UhrnwGBf0H5nhgTkHMnt97j338w+XtjQoDCU=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 h1:bvDV9vkmnHYOMsOr4WLk+Vo07yKIzd94sVoIqshQ4bU=


### PR DESCRIPTION
# What does this change
During the last release of Porter Core there was an issue where the pipeline published the canary version instead of the finalized released. This happens because the build scripts calculate the version incorrectly when multiple tags are present on the same commit.

The release process of the operator is slightly different, but updating the magefiles dependencies should ensure that the same issue is not appearing when the operator is released.

# Notes for the reviewer

# Checklist
- [ ] Did you write tests?
- [ ] Did you write documentation?
- [ ] Did you make any API changes? Update the corresponding API documentation.

[contributors]: https://getporter.org/src/CONTRIBUTORS.md